### PR TITLE
Add 'ThisDomain' collection methods

### DIFF
--- a/PowerShell/BloodHound.ps1
+++ b/PowerShell/BloodHound.ps1
@@ -4629,7 +4629,7 @@ function Invoke-BloodHound {
         $DomainController,
 
         [String]
-        [ValidateSet('Group', 'LocalGroup', 'GPOLocalGroup', 'Session', 'LoggedOn', 'Stealth', 'Trusts', 'Default')]
+        [ValidateSet('Group', 'LocalGroup', 'GPOLocalGroup', 'Session', 'LoggedOn', 'ThisDomain', 'ThisDomainStealth', 'Stealth', 'Trusts', 'Default')]
         $CollectionMethod = 'Default',
 
         [Switch]
@@ -4676,12 +4676,27 @@ function Invoke-BloodHound {
             'Session'       { $UseSession = $True; $SkipGCDeconfliction = $False }
             'LoggedOn'      { $UseLoggedOn = $True; $SkipGCDeconfliction = $True }
             'Trusts'        { $UseDomainTrusts = $True; $SkipComputerEnumeration = $True; $SkipGCDeconfliction = $True }
+            'ThisDomainStealth' {
+                $UseGroup = $True
+                $UseGPOGroup = $True
+                $UseSession = $True
+                $UseDomainTrusts = $False
+                $SkipGCDeconfliction = $True
+            }
             'Stealth'       {
                 $UseGroup = $True
                 $UseGPOGroup = $True
                 $UseSession = $True
                 $UseDomainTrusts = $True
                 $SkipGCDeconfliction = $False
+            }
+            'ThisDomain'    {
+                $UseGroup = $True
+                $UseLocalGroup = $True
+                $UseSession = $True
+                $UseLoggedOn = $False
+                $UseDomainTrusts = $False
+                $SkipGCDeconfliction = $True
             }
             'Default'       {
                 $UseGroup = $True


### PR DESCRIPTION
I've added two more collection methods for 'ThisDomain'. The idea was to avoid the GC deconfliction and domain trusts. This is an attempt to solve errors related to issue #39 and when the scope is really just a child domain. This resulted in a workable solution in a child domain of a forest with dozens of other child domains and over a million user objects.
