### PR TITLE
Base cypher queries rewrite

### DIFF
--- a/src/components/SearchContainer/Tabs/GroupNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/GroupNodeData.jsx
@@ -50,7 +50,7 @@ export default class GroupNodeData extends Component {
 				s1.close()
 			}.bind(this))
 
-		s2.run("MATCH (n:User), (m:Group {name:{name}}), p=allShortestPaths((n)-[:MemberOf*1..]->(m)) WITH nodes(p) AS y RETURN count(distinct(filter(x in y WHERE labels(x)[0] = 'User')))", {name:payload})
+		s2.run("MATCH p = (n)-[r:MemberOf*1..]->(g:Group {name:{name}}) RETURN COUNT(n)", {name:payload})
 			.then(function(result){
 				this.setState({'unrolledMembers':result.records[0]._fields[0].low})
 				s2.close()
@@ -62,19 +62,19 @@ export default class GroupNodeData extends Component {
 				s3.close()
 			}.bind(this))
 
-		s4.run("MATCH (n:Group {name:{name}}), (target:Computer), p=shortestPath((n)-[*]->(target)) RETURN count(p)", {name:payload})
+		s4.run("MATCH p = shortestPath((g:Group {name:{name}})-[r:MemberOf|AdminTo|HasSession*1..]->(c:Computer)) RETURN COUNT(DISTINCT(c))", {name:payload})
 			.then(function(result){
 				this.setState({'derivativeAdminTo':result.records[0]._fields[0].low})
 				s4.close()
 			}.bind(this))
 
-		s5.run("MATCH (n:Group {name:{name}}), (target:Group), p=shortestPath((n)-[r:MemberOf*1..]->(target)) RETURN count(p)", {name:payload})
+		s5.run("MATCH p = (g1:Group {name:{name}})-[r:MemberOf*1..]->(g2:Group) RETURN COUNT(DISTINCT(g2))", {name:payload})
 			.then(function(result){
 				this.setState({'unrolledMemberOf':result.records[0]._fields[0].low})
 				s5.close()
 			}.bind(this))
 
-		s6.run("MATCH p=shortestPath((m:User)-[r:MemberOf*1..]->(n:Group {name: {name}})) WITH m,p MATCH q=((m)<-[:HasSession]-(o:Computer)) RETURN count(o)", {name:payload})
+		s6.run("MATCH p = (c:Computer)-[r1:HasSession]->(u:User)-[r2:MemberOf*1..]->(g:Group {name: {name}}) RETURN COUNT(r1)", {name:payload})
 			.then(function(result){
 				this.setState({'sessions':result.records[0]._fields[0].low})
 				s6.close()
@@ -118,7 +118,7 @@ export default class GroupNodeData extends Component {
 							ready={this.state.unrolledMembers !== -1}
 							value={this.state.unrolledMembers}
 							click={function(){
-								emitter.emit('query', "MATCH (n:User), (m:Group {name:{name}}), p=shortestPath((n)-[:MemberOf*1..]->(m)) RETURN p", {name: this.state.label},
+								emitter.emit('query', "MATCH p = (n)-[r:MemberOf*1..]->(g:Group {name:{name}}) RETURN p", {name: this.state.label},
 									this.state.label)
 							}.bind(this)} />
 					</dd>
@@ -131,7 +131,7 @@ export default class GroupNodeData extends Component {
 							ready={this.state.directAdminTo !== -1}
 							value={this.state.directAdminTo}
 							click={function(){
-								emitter.emit('query', "MATCH p=shortestPath((n:Group {name:{name}})-[r:AdminTo]->(m:Computer)) RETURN p", {name: this.state.label},
+								emitter.emit('query', "MATCH p=(g:Group {name:{name}})-[r:AdminTo]->(c:Computer) RETURN p", {name: this.state.label},
 									this.state.label)
 							}.bind(this)} />
 					</dd>
@@ -144,7 +144,7 @@ export default class GroupNodeData extends Component {
 							ready={this.state.derivativeAdminTo !== -1}
 							value={this.state.derivativeAdminTo}
 							click={function(){
-								emitter.emit('query', "MATCH (n:Group {name:{name}}), (target:Computer), p=shortestPath((n)-[*]->(target)) RETURN p", {name: this.state.label},
+								emitter.emit('query', "MATCH p = shortestPath((g:Group {name:{name}})-[r:MemberOf|AdminTo|HasSession*1..]->(c:Computer)) RETURN p", {name: this.state.label},
 									this.state.label)
 							}.bind(this)} />
 					</dd>
@@ -156,7 +156,7 @@ export default class GroupNodeData extends Component {
 							ready={this.state.unrolledMemberOf !== -1}
 							value={this.state.unrolledMemberOf}
 							click={function(){
-								emitter.emit('query', "MATCH (n:Group {name:{name}}), (target:Group), p=shortestPath((n)-[r:MemberOf*1..]->(target)) RETURN p", {name: this.state.label},
+								emitter.emit('query', "MATCH p = (g1:Group {name:{name}})-[r:MemberOf*1..]->(g2:Group) RETURN p", {name: this.state.label},
 									this.state.label)
 							}.bind(this)} />
 					</dd>
@@ -179,7 +179,7 @@ export default class GroupNodeData extends Component {
 							ready={this.state.sessions !== -1}
 							value={this.state.sessions}
 							click={function(){
-								emitter.emit('query', "MATCH p=shortestPath((m:User)-[r:MemberOf*1..]->(n:Group {name: {name}})) WITH m,p MATCH q=((m)<-[:HasSession]-(o:Computer)) RETURN q,p", {name: this.state.label},
+								emitter.emit('query', "MATCH p = (c:Computer)-[r1:HasSession]->(u:User)-[r2:MemberOf*1..]->(g:Group {name: {name}}) RETURN p", {name: this.state.label},
 									"",this.state.label)
 							}.bind(this)} />
 					</dd>

--- a/src/components/SearchContainer/Tabs/UserNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/UserNodeData.jsx
@@ -57,37 +57,37 @@ export default class UserNodeData extends Component {
 				s1.close()
 			}.bind(this))
 
-		s2.run("MATCH (n:User {name:{name}}), (m:Group), p=shortestPath((n)-[:MemberOf*1]->(m)) RETURN count(m)", {name:payload})
+		s2.run("MATCH (n:User {name:{name}}), (m:Group), p=(n)-[:MemberOf]->(m) RETURN count(m)", {name:payload})
 			.then(function(result){
 				this.setState({'firstDegreeGroupMembership':result.records[0]._fields[0].low})
 				s2.close()
 			}.bind(this))
 
-		s3.run("MATCH (n:User {name:{name}}), (target:Group), p=shortestPath((n)-[:MemberOf*1..]->(target)) RETURN count(target)", {name:payload})
+		s3.run("MATCH p = (n:User {name:{name}})-[r:MemberOf*1..]->(g:Group) RETURN COUNT(DISTINCT(g))", {name:payload})
 			.then(function(result){
 				this.setState({'unrolledGroupMembership':result.records[0]._fields[0].low})
 				s3.close()
 			}.bind(this))
 
-		s4.run("MATCH (n:User {name:{name}}), (target:Computer), p=shortestPath((n)-[:AdminTo*1]->(target)) RETURN count(target)", {name:payload})
+		s4.run("MATCH p = (n:User {name:{name}})-[r:AdminTo]->(c:Computer) RETURN COUNT(DISTINCT(c))", {name:payload})
 			.then(function(result){
 				this.setState({'firstDegreeLocalAdmin':result.records[0]._fields[0].low})
 				s4.close()
 			}.bind(this))
 
-		s5.run("MATCH p=shortestPath((n:User {name:{name}})-[r*1..]->(m:Computer)) WHERE NONE(rel in rels(p) WHERE type(rel)='HasSession') WITH p WHERE ANY(rel in rels(p) WHERE type(rel)='MemberOf') RETURN count(p)", {name:payload})
+		s5.run("MATCH p=(n:User {name:{name}})-[r1:MemberOf*1..]->(g:Group)-[r2:AdminTo]->(c:Computer) RETURN count(distinct(c))", {name:payload})
 			.then(function(result){
 				this.setState({'groupDelegatedLocalAdmin':result.records[0]._fields[0].low})
 				s5.close()
 			}.bind(this))
 
-		s6.run("MATCH (n:User {name:{name}}), (target:Computer), p=shortestPath((n)-[*]->(target)) RETURN count(p)", {name:payload})
+		s6.run("MATCH p = shortestPath((n:User {name:{name}})-[r:HasSession|AdminTo|MemberOf*1..]->(c:Computer)) RETURN COUNT(c)", {name:payload})
 			.then(function(result){
 				this.setState({'derivativeLocalAdmin':result.records[0]._fields[0].low})
 				s6.close()
 			}.bind(this))
 
-		s7.run("MATCH (n:Computer)-[r:HasSession]->(m:User {name:{name}}) RETURN count(n)", {name:payload})
+		s7.run("MATCH p = (n:Computer)-[r:HasSession]->(m:User {name:{name}}) RETURN COUNT(DISTINCT(n))", {name:payload})
 			.then(function(result){
 				this.setState({'sessions':result.records[0]._fields[0].low})
 				s7.close()
@@ -135,7 +135,7 @@ export default class UserNodeData extends Component {
 							click={function(){
 								emitter.emit(
 									'query',
-									"MATCH (n:User {name:{name}}), (target:Group),p=shortestPath((n)-[:MemberOf*1]->(target)) RETURN p", {name:this.state.label}
+									"MATCH p = (n:User {name:{name}})-[r:MemberOf]->(g:Group) RETURN p", {name:this.state.label}
 									)
 							}.bind(this)} />
 					</dd>
@@ -147,7 +147,7 @@ export default class UserNodeData extends Component {
 							ready={this.state.unrolledGroupMembership !== -1}
 							value={this.state.unrolledGroupMembership}
 							click={function(){
-								emitter.emit('query', "MATCH (n:User {name:{name}}), (target:Group),p=shortestPath((n)-[:MemberOf*1..]->(target)) RETURN p", {name:this.state.label},
+								emitter.emit('query', "MATCH p = (n:User {name:{name}})-[r:MemberOf*1..]->(g:Group) RETURN p", {name:this.state.label},
 									this.state.label)
 							}.bind(this)} />
 					</dd>
@@ -172,7 +172,7 @@ export default class UserNodeData extends Component {
 							ready={this.state.firstDegreeLocalAdmin !== -1}
 							value={this.state.firstDegreeLocalAdmin}
 							click={function(){
-								emitter.emit('query', "MATCH (n:User {name:{name}}), (target:Computer), p=shortestPath((n)-[:AdminTo*1]->(target)) RETURN p", {name:this.state.label})
+								emitter.emit('query', "MATCH p = (n:User {name:{name}})-[r:AdminTo]->(c:Computer) RETURN payload", {name:this.state.label})
 							}.bind(this)} />
 					</dd>
 					<dt>
@@ -183,7 +183,7 @@ export default class UserNodeData extends Component {
 							ready={this.state.groupDelegatedLocalAdmin !== -1}
 							value={this.state.groupDelegatedLocalAdmin}
 							click={function(){
-								emitter.emit('query', "MATCH p=shortestPath((n:User {name:{name}})-[r*1..]->(m:Computer)) WHERE NONE(rel in rels(p) WHERE type(rel)='HasSession') WITH p WHERE ANY(rel in rels(p) WHERE type(rel)='MemberOf') RETURN p", {name:this.state.label}
+								emitter.emit('query', "MATCH p=(n:User {name:{name}})-[r1:MemberOf*1..]->(g:Group)-[r2:AdminTo]->(c:Computer) RETURN p", {name:this.state.label}
 									,this.state.label)
 							}.bind(this)} />
 					</dd>
@@ -195,7 +195,7 @@ export default class UserNodeData extends Component {
 							ready={this.state.derivativeLocalAdmin !== -1}
 							value={this.state.derivativeLocalAdmin}
 							click={function(){	
-								emitter.emit('query', "MATCH (n:User {name:{name}}), (m:Computer), p=shortestPath((n)-[*]->(m)) RETURN p", {name:this.state.label}
+								emitter.emit('query', "MATCH p = shortestPath((n:User {name:{name}})-[r:HasSession|AdminTo|MemberOf*1..]->(c:Computer)) RETURN p", {name:this.state.label}
 									,this.state.label)
 							}.bind(this)} />
 					</dd>


### PR DESCRIPTION
Most of the base cypher queries within the "Computer", "Group", and "User" tabs have been re-written for significantly increased speed and accuracy. Almost all queries should now complete almost instantly. The "derivative admin to" query remains relatively slow until a good solution is found to speed that query up without losing accuracy. In general, any unnecessary use of "shortestPath" or "allShortestPaths" was removed, notably from queries where we are only traveling one degree (ie: explicit admin rights for a user node). Additionally, any query that did not explicitly define the edge types to traverse (ie: "wild card" paths) was changed to account for the updated database schema included ACL relationships. This should not have much effect on databases without ACL edges, but is necessary for those that do.