### PR TITLE
Fix README.md headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-#Downloading BloodHound Binaries
+# Downloading BloodHound Binaries
 Pre-Compiled BloodHound binaries can be found [here](https://github.com/adaptivethreat/BloodHound/releases). 
 
 The rolling release will always be updated to the most recent source. Tagged releases are considered "stable" but will likely not have new features or fixes.
 
-#About BloodHound
+# About BloodHound
 
 To get started with BloodHound, check out the [BloodHound Github Wiki.](https://github.com/adaptivethreat/Bloodhound/wiki)
 


### PR DESCRIPTION
Fix the markdown headings in README.md. The headings weren't being bolded and enlarged.