### PR TITLE
Update to Bolt result parsing in Graph.jsx

### DIFF
--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -371,48 +371,49 @@ export default class GraphContainer extends Component {
         session.run(params.statement, params.props)
             .subscribe({
                 onNext: function(result){
-                    if (result._fields[0].hasOwnProperty('segments')){
-                        $.each(result._fields, function(index, field){
-                            $.each(field.segments,function(index, segment){
-                                var end = this.createNodeFromRow(segment.end, params)
-                                var start = this.createNodeFromRow(segment.start, params)
-                                var edge = this.createEdgeFromRow(segment.relationship)
+                    $.each(result._fields, function(index, field){
+                        if (field != null){
+                            if (field.hasOwnProperty('segments')){
+                                $.each(field.segments,function(index, segment){
+                                    var end = this.createNodeFromRow(segment.end, params)
+                                    var start = this.createNodeFromRow(segment.start, params)
+                                    var edge = this.createEdgeFromRow(segment.relationship)
 
-                                if (!edges[edge.id]){
-                                    edges[edge.id] = edge
-                                }
+                                    if (!edges[edge.id]){
+                                        edges[edge.id] = edge
+                                    }
 
-                                if (!nodes[end.id]){
-                                    nodes[end.id] = end
-                                }
+                                    if (!nodes[end.id]){
+                                        nodes[end.id] = end
+                                    }
 
-                                if (!nodes[start.id]){
-                                    nodes[start.id] = start
-                                }
-                            }.bind(this))
-                        }.bind(this))
-                        
-                    }else{
-                        $.each(result._fields, function(index, value){
-                            if ($.isArray(value)){
-                                $.each(value, function(index, subval){
-                                    var id = subval.identity.low
-                                    if (subval.end && !edges.id){
-                                        edges[id] = this.createEdgeFromRow(subval)
-                                    }else if (!nodes.id){
-                                        nodes[id] = this.createNodeFromRow(subval, params)
+                                    if (!nodes[start.id]){
+                                        nodes[start.id] = start
                                     }
                                 }.bind(this))
                             }else{
-                                var id = value.identity.low
-                                if (value.end && !edges.id){
-                                    edges[id] = this.createEdgeFromRow(value)
-                                }else if (!nodes.id){
-                                    nodes[id] = this.createNodeFromRow(value, params)
+                                if ($.isArray(field)){
+                                    $.each(field, function(index, value){
+                                        if (value != null){
+                                            var id = value.identity.low
+                                            if (value.end && !edges.id){
+                                                edges[id] = this.createEdgeFromRow(value)
+                                            }else if (!nodes.id){
+                                                nodes[id] = this.createNodeFromRow(value, params)
+                                            }
+                                        }
+                                    }.bind(this))
+                                }else{
+                                    var id = field.identity.low
+                                    if (field.end && !edges.id){
+                                        edges[id] = this.createEdgeFromRow(field)
+                                    }else if (!nodes.id){
+                                        nodes[id] = this.createNodeFromRow(field, params)
+                                    }
                                 }
                             }
-                        }.bind(this))
-                    }
+                        }
+                    }.bind(this))
                 }.bind(this),
                 onError: function(error){
                     console.log(error)


### PR DESCRIPTION
This PR addresses two issues with parsing Bolt responses:

1. The nature of OPTIONAL MATCH queries means there is a potential for returning "null" fields in a Bolt result. However, this raised errors when a null field was parsed for something like "identity.low" (which doesn't exist for a null field), so the graph wouldn't end up rendering. I've added some checks so that null fields are skipped and the other potential fields (Node, Relationship, Path) are still passed along for proper rendering.

2. The original logic would check the first field in the Bolt result for a certain property: `if (result._fields[0].hasOwnProperty('segments'))`. If it existed, then it would assume there was only one field in the result and it was a Path. If it didn't exist, then it would loop through each field and assume it was either a Node, Relationship, or Array with nested Node/Relationship fields. The problem arises when a query returns both a Path and some other field (Name/Relationship). For example, if the Path was listed as the first RETURN param, then it would be rendered and all other fields would be ignored. The opposite is also true -- if a Node/Relationship was listed as the first RETURN param, then any Path fields would be ignored. I've reordered some of the logic so that each field is parsed in turn instead of having a mutual exclusion between Path and Node/Relationship fields.

I came across these while toying with some custom queries. As far as I can tell, none of the existing BloodHound queries use OPTIONAL MATCH or have a RETURN clause with both a Path and a Node/Relationship, so they shouldn't be affected by the current configuration. Merging this PR would be a boost for those using custom queries :)