### PR TITLE
Fix "Shortest Paths to Here" for GPO nodes

### DIFF
--- a/src/components/tooltip.html
+++ b/src/components/tooltip.html
@@ -42,7 +42,7 @@
      <li onclick="emitter.emit('setEnd', '{{type}}:{{guid}}')">
          <i class="glyphicon glyphicon-screenshot"> </i> Set as Ending Node
      </li>
-     <li onclick="emitter.emit('query', 'MATCH (n:GPO {name:{name}}),(m),p=allShortestPaths((m)-[r:MemberOf|AdminTo|HasSession|Contains|GpLink|Owns|DCSync|AllExtendedRights|ForceChangePassword|GenericAll|GenericWrite|WriteDacl|WriteOwner*1..]->(n)) WHERE NOT m.guid={guid} RETURN p', {name: '{{name}}'})">
+     <li onclick="emitter.emit('query', 'MATCH (n:GPO {guid:{guid}}),(m),p=allShortestPaths((m)-[r:MemberOf|AdminTo|HasSession|Contains|GpLink|Owns|DCSync|AllExtendedRights|ForceChangePassword|GenericAll|GenericWrite|WriteDacl|WriteOwner*1..]->(n)) WHERE NOT m.guid={guid} RETURN p', {guid: '{{guid}}'})">
          <i class="glyphicon glyphicon-screenshot"> </i> Shortest Paths to Here
      </li>
      {{/type_gpo}}


### PR DESCRIPTION
The original Cypher query uses both `name` and `guid` to filter, however only `name` is passed as argument.
I propose to use only the `guid`, since it is also more reliable than the name.
The "Shortest Paths to Here" feature for OUs also uses the GUID.

Before patch: right-click on a GPO -> "shortest path to here" -> query runs but never finishes (probably due to an error, I don't know how to check this)
After patch: same actions and BloodHound find paths.