### PR TITLE
Fix OUs and GPOs multi-import

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -543,7 +543,7 @@ export function buildGplinkProps(rows){
                 });
             } else {
                 datadict[type] = {
-                    statement: 'UNWIND {props} as prop MERGE (a:GPO {name: prop.gponame}) WITH a,prop MERGE (b:OU {guid: prop.objectGuid}) WITH a,b,prop MERGE (a)-[r:GpLink {enforced: toBoolean(prop.enforced), isACL: false}]->(b) SET a.guid=prop.gpoGuid,b.name=prop.objectName,a.domain=prop.gpoDomain,b.domain=prop.objectDomain',
+                    statement: 'UNWIND {props} as prop MERGE (a:GPO {name: prop.gponame}) WITH a,prop MERGE (b:OU {guid: prop.objectGuid}) WITH a,b,prop MERGE (a)-[r:GpLink {enforced: toBoolean(prop.enforced), isACL: false}]->(b) SET a.guid=prop.gpoGuid,b.name=prop.objectname,a.domain=prop.gpoDomain,a.name=prop.gponame,b.domain=prop.objectDomain',
                     props: [{
                         gponame: gpoName,
                         objectname: objectName,
@@ -567,7 +567,7 @@ export function buildGplinkProps(rows){
                 });
             } else {
                 datadict[type] = {
-                    statement: 'UNWIND {props} as prop MERGE (a:GPO {name: prop.gponame}) WITH a,prop MERGE (b:{} {name: prop.objectname}) WITH a,b,prop MERGE (a)-[r:GpLink {enforced: toBoolean(prop.enforced), isACL: false}]->(b) SET a.guid=prop.gpoGuid,a.domain=prop.gpoDomain,b.domain=prop.objectDomain'.format(type),
+                    statement: 'UNWIND {props} as prop MERGE (a:GPO {name: prop.gponame}) WITH a,prop MERGE (b:{} {name: prop.objectname}) WITH a,b,prop MERGE (a)-[r:GpLink {enforced: toBoolean(prop.enforced), isACL: false}]->(b) SET a.guid=prop.gpoGuid,a.domain=prop.gpoDomain,a.name=prop.gponame,b.name=prop.objectname,b.domain=prop.objectDomain'.format(type),
                     props: [{
                         gponame: gpoName,
                         objectname: objectName,
@@ -650,7 +650,7 @@ export function buildACLProps(rows) {
                     });
                 } else {
                     datadict[hash] = {
-                        statement: 'UNWIND {props} AS prop MERGE (a:{} {name:prop.account}) WITH a,prop MERGE (b:GPO {guid: prop.principal}) WITH a,b,prop MERGE (a)-[r:{} {isACL:true}]->(b) SET b.guid=prop.guid'.format(atype, record),
+                        statement: 'UNWIND {props} AS prop MERGE (a:{} {name:prop.account}) WITH a,prop MERGE (b:GPO {name: prop.principal}) WITH a,b,prop MERGE (a)-[r:{} {isACL:true}]->(b) SET b.guid=prop.guid'.format(atype, record),
                         props: [{ account: a, principal: b, guid:row.ObjectGuid }]
                     };
                 }


### PR DESCRIPTION
BloodHound loads the OUs and GPOs objects in neo4j with the MERGE keyword to merge identical objects and prevent creating duplicates.
The comparison is based on the names but it didn't work since I observed duplicates in my neo4j database.
It is caused by a small mistake in the query.
Also, there was a confusion between "objectname" and "objectName" leading to un-named OUs.

Before the patch: you can try to load several times the same files and notice that the number of OUs and GPOs increase in the neo4j database since duplicates are created. You can also notice that several OUs and GPOs nodes are created with only a GUID, but no names and other required attributes.
After the patch: do the same actions and notice that the number of objects do not increase since they are properly merged. Notice also that the nodes are well populated with the required attributes.