### PR TITLE
Fix "Shortest Paths to Here" and "Set as starting/ending node" for GPO nodes

### DIFF
--- a/src/components/tooltip.html
+++ b/src/components/tooltip.html
@@ -36,13 +36,13 @@
      </li>
      {{/type_group}}
      {{#type_gpo}}
-     <li onclick="emitter.emit('setStart', '{{type}}:{{guid}}')">
+     <li onclick="emitter.emit('setStart', '{{type}}:{{label}}')">
          <i class="glyphicon glyphicon-screenshot"> </i> Set as Starting Node
      </li>
-     <li onclick="emitter.emit('setEnd', '{{type}}:{{guid}}')">
+     <li onclick="emitter.emit('setEnd', '{{type}}:{{label}}')">
          <i class="glyphicon glyphicon-screenshot"> </i> Set as Ending Node
      </li>
-     <li onclick="emitter.emit('query', 'MATCH (n:GPO {name:{name}}),(m),p=allShortestPaths((m)-[r:MemberOf|AdminTo|HasSession|Contains|GpLink|Owns|DCSync|AllExtendedRights|ForceChangePassword|GenericAll|GenericWrite|WriteDacl|WriteOwner*1..]->(n)) WHERE NOT m.guid={guid} RETURN p', {name: '{{name}}'})">
+     <li onclick="emitter.emit('query', 'MATCH (n:GPO {name:{name}}),(m),p=allShortestPaths((m)-[r:MemberOf|AdminTo|HasSession|Contains|GpLink|Owns|DCSync|AllExtendedRights|ForceChangePassword|GenericAll|GenericWrite|WriteDacl|WriteOwner*1..]->(n)) WHERE NOT m.name={name} RETURN p', {name: '{{label}}'})">
          <i class="glyphicon glyphicon-screenshot"> </i> Shortest Paths to Here
      </li>
      {{/type_gpo}}


### PR DESCRIPTION
(follow-up to PR #176)
The original Cypher query uses both `name` and `guid` to filter, however only `name` is passed as argument.
I propose to use only the `name` since GPO GUIDs are not guaranteed to be unique...
To follow this spirit, also use the names to refer to GPOs in the "set as starting/ending node".

Before patch: right-click on a GPO -> "shortest path to here" -> query runs but never finishes (probably due to an error, I don't know how to check this)
After patch: same actions and BloodHound find paths.