### PR TITLE
Fix crash when using upload button

### DIFF
--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -143,15 +143,15 @@ export default class MenuContainer extends Component {
                         );
                         this.getFileMeta(file.path, callback);
                     },
-                    function done() {
+                    () => {
                         setTimeout(
-                            _ => {
+                            () => {
                                 this.setState({ uploading: false });
                             },
                             3000
                         );
                         this.addBaseProps();
-                        $.each(results, (_, file) => {
+                        $.each(results, function(_, file) {
                             if (file.delete) {
                                 unlinkSync(file.path);
                             }


### PR DESCRIPTION
Change code to fix a crash where "this" is undefined when uploading using upload button.
The fix is a simple code duplication of the fileDrop function which is correct.