### PR TITLE
Fixes broken relayout

### DIFF
--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -163,7 +163,9 @@ export default class GraphContainer extends Component {
     }
 
     getHelpEdge(id){
-        appStore.currentTooltip.close();
+        if (appStore.currentTooltip !== null){
+            appStore.currentTooltip.close();
+        }
         let instance = this.state.sigmaInstance.graph;
         let edge = instance.edges(id);
         let source = instance.nodes(edge.source);
@@ -280,7 +282,9 @@ export default class GraphContainer extends Component {
     }
 
     relayout() {
-        appStore.currentTooltip.close();
+        if (appStore.currentTooltip !== null){
+            appStore.currentTooltip.close();
+        }
         sigma.layouts.stopForceLink();
         if (appStore.dagre) {
             sigma.layouts.dagre.start(this.state.sigmaInstance);


### PR DESCRIPTION
In my test the relayout button is broken and does nothing.

The explanation is that if no tooltip is open, when `relayout()` is called then `appStore.currentTooltip` is null and it triggers an exception "TypeError: Cannot read property 'close' of null" (as seen in the console).

This fix is identical to many other cases in the same file.