### PR TITLE
Change separator character '#' to long string

### DIFF
--- a/src/components/Modals/AddEdgeModal.jsx
+++ b/src/components/Modals/AddEdgeModal.jsx
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import { Modal } from "react-bootstrap";
 import { buildSearchQuery } from 'utils';
 
+const SEPARATOR = "#BLOODHOUNDSEPARATOR#";
+
 export default class AddEdgeModal extends Component {
     constructor() {
         super();
@@ -49,7 +51,7 @@ export default class AddEdgeModal extends Component {
                             type: record._fields[0].labels[0]
                         });
                         map[index] = props;
-                        data.push(`${props.name}#${index}`);
+                        data.push(`${props.name}${SEPARATOR}${index}`);
                     })
 
                     this.map = map;
@@ -58,11 +60,11 @@ export default class AddEdgeModal extends Component {
                 })
             },
             updater: function(item){
-                let [_, index] = item.split('#');
+                let [_, index] = item.split(SEPARATOR);
                 return this.map[index];
             },
             matcher: function(item){
-                let [name,index] = item.split('#');
+                let [name,index] = item.split(SEPARATOR);
                 let obj = this.map[index];
                 let searchTerm = this.query.includes(':') ? this.query.split(':')[1] : this.query;
 
@@ -75,7 +77,7 @@ export default class AddEdgeModal extends Component {
                 }
             },
             highlighter: function(item){
-                let [name,index] = item.split('#');
+                let [name,index] = item.split(SEPARATOR);
                 let obj = this.map[index];
                 let searchTerm = this.query.includes(':') ? this.query.split(':')[1] : this.query;
                 let type = obj.type;

--- a/src/components/SearchContainer/SearchContainer.jsx
+++ b/src/components/SearchContainer/SearchContainer.jsx
@@ -4,6 +4,8 @@ import Icon from "../Icon";
 import TabContainer from "./TabContainer";
 import { buildSearchQuery, buildSelectQuery } from "utils";
 
+const SEPARATOR = "#BLOODHOUNDSEPARATOR#";
+
 export default class SearchContainer extends Component {
     constructor(props) {
         super(props);
@@ -73,7 +75,7 @@ export default class SearchContainer extends Component {
                             type: record._fields[0].labels[0]
                         });
                         map[index] = props;
-                        data.push(`${props.name}#${index}`);
+                        data.push(`${props.name}${SEPARATOR}${index}`);
                     })
 
                     this.map = map;
@@ -113,13 +115,13 @@ export default class SearchContainer extends Component {
             }.bind(this),
             autoSelect: false,
             updater: function (item) {
-                let spl = item.split("#");
+                let spl = item.split(SEPARATOR);
                 let index = spl[1];
                 let obj = this.map[index];
                 return obj;
             },
             matcher: function (item) {
-                let spl = item.split("#");
+                let spl = item.split(SEPARATOR);
                 let name = spl[0];
                 let index = spl[1];
                 let obj = this.map[index];
@@ -144,7 +146,7 @@ export default class SearchContainer extends Component {
                 }
             },
             highlighter: function (item) {
-                let spl = item.split("#");
+                let spl = item.split(SEPARATOR);
                 let name = spl[0];
                 let index = spl[1];
                 let obj = this.map[index];
@@ -210,7 +212,7 @@ export default class SearchContainer extends Component {
                             type: record._fields[0].labels[0]
                         });
                         map[index] = props;
-                        data.push(`${props.name}#${index}`);
+                        data.push(`${props.name}${SEPARATOR}${index}`);
                         index++;
                     })
 
@@ -237,13 +239,13 @@ export default class SearchContainer extends Component {
             }.bind(this),
             autoSelect: false,
             updater: function (item) {
-                let spl = item.split("#");
+                let spl = item.split(SEPARATOR);
                 let index = spl[1];
                 let obj = this.map[index];
                 return obj;
             },
             matcher: function (item) {
-                let spl = item.split("#");
+                let spl = item.split(SEPARATOR);
                 let name = spl[0];
                 let index = spl[1];
                 let obj = this.map[index];
@@ -268,7 +270,7 @@ export default class SearchContainer extends Component {
                 }
             },
             highlighter: function (item) {
-                let spl = item.split("#");
+                let spl = item.split(SEPARATOR);
                 let name = spl[0];
                 let index = spl[1];
                 let obj = this.map[index];


### PR DESCRIPTION
Fix #232

The idea is that there is a very low chance that this string is used in a legitimate AD object.
A cleaner solution would be to use an array with 2 elements, or a tuple to prevent creating then splitting the string just after. But it doesn't seem to work well with typeahead