### PR TITLE
Fix DCSync Prebuilt query

### DIFF
--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -47,7 +47,7 @@
                 {
                     "final": true,
                     "query":
-                        "MATCH (n1)-[:MemberOf|GetChanges*1..]->(u:Domain {name: {name}}) WITH n1,u MATCH (n1)-[:MemberOf|GetChangesAll*1..]->(u) WITH n1,u MATCH p = (n1)-[:MemberOf|GetChanges|GetChangesAll*1..]->(u) RETURN p",
+                        "MATCH (n1)-[:MemberOf|GetChanges*1..]->(u:Domain {name: {result}}) WITH n1,u MATCH (n1)-[:MemberOf|GetChangesAll*1..]->(u) WITH n1,u MATCH p = (n1)-[:MemberOf|GetChanges|GetChangesAll*1..]->(u) RETURN p",
                     "allowCollapse": true,
                     "endNode": "{}"
                 }


### PR DESCRIPTION
Query gets stuck because of wrong parameter name.

Fixed parameter from `name` to `result`