### PR TITLE
Shortestpath to DA from User or Computer nodes

### DIFF
--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -29,7 +29,7 @@
                 {
                     "final": true,
                     "query":
-                        "MATCH (n:User),(m:Group {name:{result}}),p=shortestPath((n)-[r:{}*1..]->(m)) RETURN p",
+                        "MATCH (n),(m:Group {name:{result}}),p=shortestPath((n)-[r:{}*1..]->(m)) WHERE (n:User) OR (n:Computer) RETURN p",
                     "allowCollapse": true,
                     "endNode": "{}"
                 }


### PR DESCRIPTION
This query currently tries to find shortest path from User nodes to Domain Admin group.
Usually, during assessement, the typical nodes that can be owned are User **and** Computer nodes.

This commit just updates the `(n:User)` with a more generic `(n)`, adding a `WHERE` condition to include User and Computer nodes.

It is working great on low-mid-size environement (5k users), but it is of course slower.

If you have a more efficient way to do it, I'm all ears ! :)