### PR TITLE
Add shortest path from owned principals

### DIFF
--- a/src/components/nodeTooltip.html
+++ b/src/components/nodeTooltip.html
@@ -43,6 +43,31 @@
         <i class="fa fa-random"> </i> Shortest Paths to Here
     </li>
     {{/type_domain}}
+    {{#type_user}}
+    <li onclick="emitter.emit('query', 'MATCH (n:User {name:{name}}),(m {owned: true}),p=shortestPath((m)-[r:{}*1..]->(n)) WHERE NOT m=n RETURN p', {name: '{{label}}'}, '{{label}}')">
+        <i class="fa fa-skull"> </i> Shortest Paths to Here from Owned Principals
+    </li>
+    {{/type_user}} {{#type_computer}}
+    <li onclick="emitter.emit('query', 'MATCH (n:Computer {name:{name}}),(m {owned: true}),p=shortestPath((m)-[r:{}*1..]->(n)) WHERE NOT m=n RETURN p', {name: '{{label}}'}, '{{label}}')">
+        <i class="fa fa-skull"> </i> Shortest Paths to Here from Owned Principals
+    </li>
+    {{/type_computer}} {{#type_group}}
+    <li onclick="emitter.emit('query', 'MATCH (n:Group {name:{name}}),(m {owned: true}),p=shortestPath((m)-[r:{}*1..]->(n)) WHERE NOT m=n RETURN p', {name: '{{label}}'}, '{{label}}')">
+        <i class="fa fa-skull"> </i> Shortest Paths to Here from Owned Principals
+    </li>
+    {{/type_group}} {{#type_gpo}}
+    <li onclick="emitter.emit('query', 'MATCH (n:GPO {name:{name}}),(m {owned: true}),p=shortestPath((m)-[r:{}*1..]->(n)) WHERE NOT m=n RETURN p', {name: '{{label}}'}, '{{label}}')">
+        <i class="fa fa-skull"> </i> Shortest Paths to Here from Owned Principals
+    </li>
+    {{/type_gpo}} {{#type_ou}}
+    <li onclick="emitter.emit('query', 'MATCH (n:OU {guid:{guid}}),(m {owned: true}),p=shortestPath((m)-[r:{}*1..]->(n)) WHERE NOT m=n RETURN p', {guid: '{{guid}}'}, '{{label}}')">
+        <i class="fa fa-skull"> </i> Shortest Paths to Here from Owned Principals
+    </li>
+    {{/type_ou}} {{#type_domain}}
+    <li onclick="emitter.emit('query', 'MATCH (n:Domain {name:{name}}),(m {owned: true}),p=shortestPath((m)-[r:{}*1..]->(n)) WHERE NOT m=n RETURN p', {name: '{{label}}'}, '{{label}} ')">
+        <i class="fa fa-skull"> </i> Shortest Paths to Here from Owned Principals
+    </li>
+    {{/type_domain}}
     {{#type_ou}}
     <li onclick="emitter.emit('editnode', '{{guid}}', '{{type}}')">
         <i class="fa fa-edit"> </i> Edit Node


### PR DESCRIPTION
During an internal pentest, it was in a secured environment, and I very often had to check how I could reach a target from my owned nodes. Currently, there is no easy way (point and click) to do this that I know of, so I just added a menu for this in the right-click context menu.

![image](https://user-images.githubusercontent.com/11051803/56601138-b4240680-65fa-11e9-8651-a1f065018048.png)

![image](https://user-images.githubusercontent.com/11051803/56601156-bc7c4180-65fa-11e9-9870-1668821af60e.png)

I use it **a lot ** so I thought it could be useful for others.

Cheerz 