### PR TITLE
Fix JSON file exports by switching to synchrounous writeFile

### DIFF
--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { findGraphPath, generateUniqueId } from 'utils';
-import { writeFile, readFile } from 'fs';
+import { writeFileSync, readFile } from 'fs';
 import { fork } from 'child_process';
 var child;
 import { join } from 'path';
@@ -398,7 +398,7 @@ class GraphContainer extends Component {
             });
 
             if (r !== undefined) {
-                writeFile(r, JSON.stringify(json, null, 2));
+                writeFileSync(r, JSON.stringify(json, null, 2));
             }
         }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ import AlertTemplate from 'react-alert-template-basic';
 import { remote, shell } from 'electron';
 const { app } = remote;
 import { join } from 'path';
-import { stat, writeFile, existsSync, mkdirSync } from 'fs';
+import { stat, writeFileSync, existsSync, mkdirSync } from 'fs';
 
 import ConfigStore from 'electron-store';
 global.conf = new ConfigStore();
@@ -345,7 +345,7 @@ var custompath = join(app.getPath('userData'), 'customqueries.json');
 
 stat(custompath, function(err, stats) {
     if (err) {
-        writeFile(custompath, '{}');
+        writeFileSync(custompath, '{}');
     }
 });
 


### PR DESCRIPTION
Otherwise the export fails and we get this error:
![image](https://user-images.githubusercontent.com/550823/66399630-428d1880-e9e0-11e9-9987-90c784f29da8.png)

Reference: https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback
Because `callback` is not an optional argument

Alternative solution if we stay with async writeFile: implement a proper callback function.