### PR TITLE
Fix image export in dark mode

### DIFF
--- a/src/components/Graph.jsx
+++ b/src/components/Graph.jsx
@@ -375,13 +375,14 @@ class GraphContainer extends Component {
     export(payload) {
         if (payload === 'image') {
             let size = $('#graph').outerWidth();
+            let bgColor = this.state.darkMode ? '#383332' : '#f2f5f9';
             sigma.plugins.image(
                 this.state.sigmaInstance,
                 this.state.sigmaInstance.renderers[0],
                 {
                     download: true,
                     size: size,
-                    background: 'lightgray',
+                    background: bgColor,
                     clip: true,
                 }
             );


### PR DESCRIPTION
When exporting images of graphs in dark mode, the background is set to 'lightgray', but the labels are still white which makes the actual pictures unreadable. So instead of setting a specific color, this retains the color of the current mode.

The expected behavior might be to always output light mode images, but the image plugin does not support changing label colors as easy as the background. So a feature like that would perhaps require a bigger rewrite.