### PR TITLE
Add info alert when unzipping files

### DIFF
--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -177,6 +177,10 @@ class MenuContainer extends Component {
             var path = files[index].path;
             var name = files[index].name;
 
+            this.props.alert.info(
+                'Unzipping file {}'.format(name)
+            );
+            
             if (isZipSync(path)) {
                 await createReadStream(path)
                     .pipe(Parse())


### PR DESCRIPTION
Unzipping large files might take a few seconds and (impatient) users might think something is not working if they don't have visual feedback
Prevents #301