### PR TITLE
Fix URL check breaking login process in case of success

### DIFF
--- a/src/components/Float/Login.jsx
+++ b/src/components/Float/Login.jsx
@@ -233,7 +233,14 @@ const Login = () => {
 
         session
             .run('MATCH (n) RETURN n LIMIT 1')
-            .then(result => {})
+            .then(result => {
+                icon.removeClass();
+                icon.addClass(
+                    'fa fa-check-circle green-icon-color form-control-feedback'
+                );
+                setLoginEnabled(true);
+                setUrl(tempUrl);
+            })
             .catch(error => {
                 if (error.message.includes('WebSocket connection failure')) {
                     icon.removeClass();
@@ -253,7 +260,8 @@ const Login = () => {
                     setLoginEnabled(true);
                     setUrl(tempUrl);
                 }
-
+            })
+            .finally(() => {
                 session.close();
                 driver.close();
             });


### PR DESCRIPTION
Fix rare case where connection success with empty credentials totally breaks the login process. This is happening when using Neo4j in Docker when launching without specifying creds for example.