### PR TITLE
Fix adding neo4j repo to sources

### DIFF
--- a/docs/installation/linux.rst
+++ b/docs/installation/linux.rst
@@ -27,7 +27,7 @@ Install neo4j
 ::
 
   wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-  echo 'deb https://debian.neo4j.com stable 4.0' > /etc/apt/sources.list.d/neo4j.list
+  echo 'deb https://debian.neo4j.com stable 4.0' | sudo tee -a /etc/apt/sources.list.d/neo4j.list
   sudo apt-get update
 
 2. Install apt-transport-https with apt


### PR DESCRIPTION
Redirect carrot uses user permissions instead of sudo. Proposed change is to use tee instead.