### PR TITLE
Use "Domain Admins" group's SID instead of name in "Find Domain Admin Logons to non-Domain Controllers" query

### DIFF
--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -320,10 +320,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (c:Computer)-[:MemberOf]->(t:Group) WHERE NOT t.name STARTS WITH 'DOMAIN CONTROLLERS' WITH c as NonDC MATCH p=(NonDC)-[:HasSession]->(n:User)-[:MemberOf]-> (g:Group) WHERE g.objectid =~ $name RETURN p",
-                    "props": {
-                        "name": "(?i)S-1-5-.*-512"
-                    },
+                    "query": "MATCH (c:Computer)-[:MemberOf]->(t:Group) WHERE NOT t.name STARTS WITH 'DOMAIN CONTROLLERS' WITH c as NonDC MATCH p=(NonDC)-[:HasSession]->(n:User)-[:MemberOf]-> (g:Group) WHERE g.objectid ENDS WITH '-512' RETURN p",
                     "allowCollapse": true
                 }
             ]

--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -320,7 +320,10 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (c:Computer)-[:MemberOf]->(t:Group) WHERE NOT t.name STARTS WITH 'DOMAIN CONTROLLERS' WITH c as NonDC MATCH p=(NonDC)-[:HasSession]->(n:User)-[:MemberOf]-> (g:Group) WHERE g.name STARTS WITH 'DOMAIN ADMINS' RETURN p",
+                    "query": "MATCH (c:Computer)-[:MemberOf]->(t:Group) WHERE NOT t.name STARTS WITH 'DOMAIN CONTROLLERS' WITH c as NonDC MATCH p=(NonDC)-[:HasSession]->(n:User)-[:MemberOf]-> (g:Group) WHERE g.objectid =~ $name RETURN p",
+                    "props": {
+                        "name": "(?i)S-1-5-.*-512"
+                    },
                     "allowCollapse": true
                 }
             ]


### PR DESCRIPTION
Current code has false positives: e.g. "Domain Admins Something@domain". That could be fixed by adding '@' in the "STARTS WITH" clause though...
But also false negatives if the "Domain Admin"s group was renamed so it's better to use SID instead, like in other queries that I took inspiration from :)

Caution: I didn't test my code because I don't have this case in my test environment