### PR TITLE
Fix "Find Computers with Unsupported Operating Systems" query

### DIFF
--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -330,7 +330,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (n:Computer) WHERE n.operatingsystem =~ '(?i).*\\b(2000|2003|2008|xp|vista|7|me)\\b.*' RETURN n",
+                    "query": "MATCH (n:Computer) WHERE n.operatingsystem =~ '(?i).*\\\\b(2000|2003|2008|xp|vista|7|me)\\\\b.*' RETURN n",
                     "allowCollapse": true
                 }
             ]

--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -330,7 +330,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (n:Computer) WHERE n.operatingsystem =~ '(?i).(2000|2003|2008|xp|vista|7|me).' RETURN n",
+                    "query": "MATCH (n:Computer) WHERE n.operatingsystem =~ '(?i).*\\b(2000|2003|2008|xp|vista|7|me)\\b.*' RETURN n",
                     "allowCollapse": true
                 }
             ]


### PR DESCRIPTION
Replaced `.` by `.*` to search anywhere in the string (like a "contains") otherwise it didn't work!
Also added `\b` delimiters to ensure we match those keywords as single-words only. Otherwise "**xp**" would match in "Linux E**xp**erience" (hypothetical example!)
There's double escaping: one pass for neo4j, and one pass for JSON!

My tests show no regression, and a good filtering of a few false positives