### PR TITLE
Fix refresh bug with OUs of the same name

### DIFF
--- a/src/components/SearchContainer/Tabs/OUNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/OUNodeData.jsx
@@ -42,7 +42,7 @@ const OUNodeData = () => {
                 .then(r => {
                     let props = r.records[0].get('node').properties;
                     setNodeProps(props);
-                    setLabel(props.name || objectid);
+                    setLabel([...props.name] || objectid);
                     session.close();
                 });
         } else {


### PR DESCRIPTION
Fixes issue where various node info properties will not refresh when directly switching between OUs of the same name.