### PR TITLE
setStart/setEnd: Remove specific handling of OU nodes

### DIFF
--- a/src/components/Tooltips/NodeTooltip.jsx
+++ b/src/components/Tooltips/NodeTooltip.jsx
@@ -45,42 +45,21 @@ const NodeTooltip = ({ node, x, y }) => {
         >
             <div>{label}</div>
             <ul>
-                <If condition={type === 'OU'}>
-                    <Then>
-                        <li
-                            onClick={() => {
-                                emitter.emit('setStart', `${type}:${objectid}`);
-                            }}
-                        >
-                            <i className='fa fa-map-marker-alt' /> Set as
-                            Starting Node
-                        </li>
-                        <li
-                            onClick={() => {
-                                emitter.emit('setEnd', `${type}:${objectid}`);
-                            }}
-                        >
-                            <i className='fa fa-bullseye' /> Set as Ending Node
-                        </li>
-                    </Then>
-                    <Else>
-                        <li
-                            onClick={() => {
-                                emitter.emit('setStart', node);
-                            }}
-                        >
-                            <i className='fa fa-map-marker-alt' /> Set as
-                            Starting Node
-                        </li>
-                        <li
-                            onClick={() => {
-                                emitter.emit('setEnd', node);
-                            }}
-                        >
-                            <i className='fa fa-bullseye' /> Set as Ending Node
-                        </li>
-                    </Else>
-                </If>
+                <li
+                    onClick={() => {
+                        emitter.emit('setStart', node);
+                    }}
+                >
+                    <i className='fa fa-map-marker-alt' /> Set as
+                    Starting Node
+                </li>
+                <li
+                    onClick={() => {
+                        emitter.emit('setEnd', node);
+                    }}
+                >
+                    <i className='fa fa-bullseye' /> Set as Ending Node
+                </li>
                 <li
                     onClick={() => {
                         emitter.emit(


### PR DESCRIPTION
It makes everything crashes when we select an OU node and right-click "set as starting/ending node" because the "setStart/setEnd" event expects a node object and not "OU:<ID>"

I don't know why OU nodes have a special handling... Maybe some old code :)