### PR TITLE
Fixing bug: Relationship not created for Service Principal Owner of Azure Resource Group

### DIFF
--- a/Collectors/AzureHound.ps1
+++ b/Collectors/AzureHound.ps1
@@ -581,15 +581,11 @@ function Invoke-AzureHound {
                 If ($ControllerType -eq "User") {
                     $Controller = Get-AzureADUser -ObjectID $Role.ObjectID
                     $OnPremID = $Controller.OnPremisesSecurityIdentifier
-                }
-                
-                If ($ControllerType -eq "Group") {
+                } elseIf ($ControllerType -eq "Group") {
                     $Controller = Get-AzureADGroup -ObjectID $Role.ObjectID
                     $OnPremID = $Controller.OnPremisesSecurityIdentifier
-                }
-				
-				If ($ControllerType -eq "ServicePrincipal") {
-                    $Controller = Get-AzureADServicePrincipal -ObjectID $Role.ObjectID
+                } else {
+                    # e.g. ServicePrincipal
                     $OnPremID = $null
                 }
             
@@ -660,11 +656,12 @@ function Invoke-AzureHound {
                 If ($ControllerType -eq "User") {
                     $Controller = Get-AzureADUser -ObjectID $Role.ObjectID
                     $OnPremID = $Controller.OnPremisesSecurityIdentifier
-                }
-                
-                If ($ControllerType -eq "Group") {
+                } elseIf ($ControllerType -eq "Group") {
                     $Controller = Get-AzureADGroup -ObjectID $Role.ObjectID
                     $OnPremID = $Controller.OnPremisesSecurityIdentifier
+                } else {
+                    # e.g. ServicePrincipal
+                    $OnPremID = $null
                 }
 
                 $RGPrivilege = [PSCustomObject]@{
@@ -733,11 +730,12 @@ function Invoke-AzureHound {
                 If ($ControllerType -eq "User") {
                     $Controller = Get-AzureADUser -ObjectID $Role.ObjectID
                     $OnPremID = $Controller.OnPremisesSecurityIdentifier
-                }
-                
-                If ($ControllerType -eq "Group") {
+                } elseIf ($ControllerType -eq "Group") {
                     $Controller = Get-AzureADGroup -ObjectID $Role.ObjectID
                     $OnPremID = $Controller.OnPremisesSecurityIdentifier
+                } else {
+                    # e.g. ServicePrincipal
+                    $OnPremID = $null
                 }
 
                 $KVPrivilege = [PSCustomObject]@{

--- a/src/components/SearchContainer/Tabs/AZUserNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZUserNodeData.jsx
@@ -157,7 +157,7 @@ const AZUserNodeData = () => {
                                     property='First Degree Object Control'
                                     target={objectid}
                                     baseQuery={
-                                        'MATCH p = (g:AZUser {objectid: $objectid})-[r:AZResetPassword|AZAddMembers|AZOwnsAZAvereContributor|AZVMContributor|AZContributor]->(n)'
+                                        'MATCH p = (g:AZUser {objectid: $objectid})-[r:AZResetPassword|AZAddMembers|AZOwnsAZAvereContributor|AZVMContributor|AZContributor|AZOwns]->(n)'
                                     }
                                     start={label}
                                     distinct
@@ -166,7 +166,7 @@ const AZUserNodeData = () => {
                                     property='Group Delegated Object Control'
                                     target={objectid}
                                     baseQuery={
-                                        'MATCH p = (g1:AZUser {objectid: $objectid})-[r1:MemberOf*1..]->(g2)-[r2:AZResetPassword|AZAddMembers|AZOwnsAZAvereContributor|AZVMContributor|AZContributor]->(n)'
+                                        'MATCH p = (g1:AZUser {objectid: $objectid})-[r1:MemberOf*1..]->(g2)-[r2:AZResetPassword|AZAddMembers|AZOwnsAZAvereContributor|AZVMContributor|AZContributor|AZOwns]->(n)'
                                     }
                                     start={label}
                                     distinct
@@ -175,7 +175,7 @@ const AZUserNodeData = () => {
                                     property='Transitive Object Control'
                                     target={objectid}
                                     baseQuery={
-                                        'MATCH (n) WHERE NOT n.objectid=$objectid WITH n MATCH p = shortestPath((g:AZUser {objectid: $objectid})-[r:AZMemberOf|AZResetPassword|AZAddMembers|AZOwnsAZAvereContributor|AZVMContributor|AZContributor*1..]->(n))'
+                                        'MATCH (n) WHERE NOT n.objectid=$objectid WITH n MATCH p = shortestPath((g:AZUser {objectid: $objectid})-[r:AZMemberOf|AZResetPassword|AZAddMembers|AZOwnsAZAvereContributor|AZVMContributor|AZContributor|AZOwns*1..]->(n))'
                                     }
                                     start={label}
                                     distinct

--- a/src/js/newingestion.js
+++ b/src/js/newingestion.js
@@ -1052,7 +1052,7 @@ export function buildAzureAppToSP(chunk) {
     let queries = {};
     queries.properties = {
         statement:
-            'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:AZApp SET n.name = prop.AppName',
+            'UNWIND $props AS prop MERGE (n:Base {objectid: prop.source}) SET n:AZApp SET n.name = prop.name',
         props: [],
     };
     let format = [


### PR DESCRIPTION
This fixes a bug I've seen while using the new collector.

The Azure portal shows me that an App has the Owner permission over a certain Resource Group. However BloodHound did not show a relationship between the App and the Owner. Looking directly in the Neo4j database did not show a relationship either. 

This appears to be a bug in the AzureHound.ps1 collector. Here's what I observed, my understanding of the root cause, and how I've fixed it:

- The expected relationship was visible in the Azure Portal, but not in BloodHound after import.
- The expected relationship is present in the JSON file (`*-azrgpermissions.json`).
- Despite being a `ServicePrincipal`, the entry has a non-null `ControllerOnPremID`.
- This initially appears to be impossible, according to the PowerShell collector: no `OnPremId` should be set in this case
- In the collected data, the `ControllerOnPremID` is identical to the previous entry's `ControllerOnPremID`
- This is because the variable `$OnPremId` is not reset to `$null` on a subsequent loop; it retains its value from the previous loop, and so writes invalid data in on the next loop through.
- When importing this file, BloodHound (rightfully) ignores the case where a `ServicePrincipal` also has an on-prem ID:
https://github.com/BloodHoundAD/BloodHound/blob/master/src/js/newingestion.js#L1183, but this leads to the manifestation of the bug caused earlier in the process

I have tested this fix against a tenancy with this issue, and it resolved it for me.

I also noticed the same code existed within the Key Vaults section, so I made a similar change for that, although I couldn't test this in my tenancy. The same pattern exists in the VMs section, except that code did set `OnPremId` to `$null`. There was however an unnecessary call to `Get-AzureADServicePrincipal`; I removed it to make the three sections consistent.

Here's a redacted extract from the `*-azrgpermissions.json` file containing the issue:

```{
    "RGID":  "/subscriptions/<subscription guid>/resourceGroups/<rg name>",
    "ControllerName":  "Controller1",
    "ControllerID":  "<Controller1 guid>",
    "ControllerType":  "Group",
    "ControllerOnPremID":  "S-1-5-21-<sid>",
    "RoleName":  "Some Custom Role",
    "RoleDefinitionId":  "<some custom guid>"
},
{
    "RGID":  "/subscriptions/<subscription guid>/resourceGroups/<rg name>",
    "ControllerName":  "Controller2",
    "ControllerID":  "<Controller2 guid>",
    "ControllerType":  "ServicePrincipal",
    "ControllerOnPremID":  "S-1-5-21-<same sid as above>",
    "RoleName":  "Owner",
    "RoleDefinitionId":  "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
},
```

After the fix, running the collector:

```{
    "RGID":  "/subscriptions/<subscription guid>/resourceGroups/<rg name>",
    "ControllerName":  "Controller1",
    "ControllerID":  "<Controll1 guid>",
    "ControllerType":  "Group",
    "ControllerOnPremID":  "S-1-5-21-<sid>",
    "RoleName":  "Some Custom Role",
    "RoleDefinitionId":  "<some custom guid>"
},
{
    "RGID":  "/subscriptions/<subscription guid>/resourceGroups/<rg name>",
    "ControllerName":  "Controller2",
    "ControllerID":  "<Controller2 guid>",
    "ControllerType":  "ServicePrincipal",
    "ControllerOnPremID":  null,
    "RoleName":  "Owner",
    "RoleDefinitionId":  "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
},
```