### PR TITLE
Fixed Typo in Abuse Info section of SQL Admin

### DIFF
--- a/docs/data-analysis/edges.rst
+++ b/docs/data-analysis/edges.rst
@@ -710,7 +710,7 @@ Abuse Info
 
 Scott Sutherland from NetSPI has authored PowerUpSQL, a PowerShell Toolkit for Attacking SQL
 Server. Major contributors include Antti Rantasaari, Eric Gruber, and Thomas Elling. Before
-executing any of the below commands, download PowerUpSQL and laod it into your PowerShell
+executing any of the below commands, download PowerUpSQL and load it into your PowerShell
 instance. Get PowerUpSQL here: https://github.com/NetSPI/PowerUpSQL
 
 **Finding Data**

--- a/src/components/Modals/HelpTexts/SQLAdmin/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/SQLAdmin/Abuse.jsx
@@ -1,6 +1,6 @@
 import { typeFormat } from '../Formatter';
 const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = `Scott Sutherland (<a href="https://twitter.com/_nullbind">@nullbind</a>) from NetSPI has authored PowerUpSQL, a PowerShell Toolkit for Attacking SQL Server. Major contributors include Antti Rantasaari, Eric Gruber (<a href="https://twitter.com/egru">@egru</a>), and Thomas Elling (<a href="https://github.com/thomaselling">@thomaselling</a>). Before executing any of the below commands, download PowerUpSQL and laod it into your PowerShell instance. Get PowerUpSQL here: <a href="https://github.com/NetSPI/PowerUpSQL">https://github.com/NetSPI/PowerUpSQL</a>.
+    let text = `Scott Sutherland (<a href="https://twitter.com/_nullbind">@nullbind</a>) from NetSPI has authored PowerUpSQL, a PowerShell Toolkit for Attacking SQL Server. Major contributors include Antti Rantasaari, Eric Gruber (<a href="https://twitter.com/egru">@egru</a>), and Thomas Elling (<a href="https://github.com/thomaselling">@thomaselling</a>). Before executing any of the below commands, download PowerUpSQL and load it into your PowerShell instance. Get PowerUpSQL here: <a href="https://github.com/NetSPI/PowerUpSQL">https://github.com/NetSPI/PowerUpSQL</a>.
 
     <h4>Finding Data</h4>
     Get a list of databases, sizes, and encryption status:


### PR DESCRIPTION
A typo could be found in Help: SQL Admin, "laod" was specified when it should be "load"
![image](https://user-images.githubusercontent.com/44957111/116318686-28ae5480-a783-11eb-900f-b25161065c88.png)

Keep up the good work, all <3