### PR TITLE
Fix Pre-Built query that was only valid for Neo4J

### DIFF
--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -325,7 +325,7 @@
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH (u:User {hasspn:true}) OPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer) OPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer) WITH u,COLLECT(c1) + COLLECT(c2) AS tempVar UNWIND tempVar AS comps RETURN u.name,COUNT(DISTINCT(comps)) ORDER BY COUNT(DISTINCT(comps)) DESC",
+                    "query": "MATCH (u:User {hasspn:true}) OPTIONAL MATCH p1=(u)-[:AdminTo]->(c1:Computer) OPTIONAL MATCH p2=(u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer) WITH u,COLLECT(p1) + COLLECT(p2) AS tempVar UNWIND tempVar AS comps RETURN comps",
                     "allowCollapse": true
                 }
             ]


### PR DESCRIPTION
Prebuilt Queries should work in BH GUI, but **Find Kerberoastable Users with most privileges** was returning specific node's attributes. This PR fixes it and returns Kerberoastable users and their path to administration rights.