### PR TITLE
Analysis tab remake and new custom query modal for interactive query creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1425,6 +1425,25 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.14.0.tgz",
       "integrity": "sha512-OfdMsF+ZQgdKHP9jUbmDcRrP0eX90XXrsXIdyjLbkmSBzmMXPABB8eobUJtivaupucYaByz6WNe1PI1JuYm3qA=="
     },
+    "@hypnosphi/create-react-context": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz",
+      "integrity": "sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
     "@popmotion/easing": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
@@ -2578,6 +2597,15 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2851,9 +2879,9 @@
       "dev": true
     },
     "compute-scroll-into-view": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz",
-      "integrity": "sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ=="
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+      "integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -3138,25 +3166,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
       }
     },
     "cross-env": {
@@ -3964,6 +3973,7 @@
       "version": "1.17.6",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
       "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
@@ -3982,6 +3992,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -5346,6 +5357,16 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -5620,6 +5641,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -5970,9 +6006,13 @@
       }
     },
     "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -5999,7 +6039,8 @@
     "is-callable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -6109,6 +6150,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -7025,15 +7067,16 @@
     "object-inspect": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
     },
     "object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
@@ -7062,6 +7105,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -8038,12 +8082,12 @@
       }
     },
     "react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.11.tgz",
+      "integrity": "sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==",
       "requires": {
         "@babel/runtime": "^7.1.2",
-        "create-react-context": "^0.3.0",
+        "@hypnosphi/create-react-context": "^0.3.1",
         "deep-equal": "^1.1.1",
         "popper.js": "^1.14.4",
         "prop-types": "^15.6.1",
@@ -8601,12 +8645,12 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
-      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "regexpu-core": {
@@ -8849,11 +8893,11 @@
       }
     },
     "scroll-into-view-if-needed": {
-      "version": "2.2.26",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.26.tgz",
-      "integrity": "sha512-SQ6AOKfABaSchokAmmaxVnL9IArxEnLEX9j4wAZw+x4iUTb40q7irtHG3z4GtAWz5veVZcCnubXDBRyLVQaohw==",
+      "version": "2.2.28",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.28.tgz",
+      "integrity": "sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==",
       "requires": {
-        "compute-scroll-into-view": "^1.0.16"
+        "compute-scroll-into-view": "^1.0.17"
       }
     },
     "semver": {
@@ -9398,6 +9442,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -9407,6 +9452,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"

--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -26,6 +26,7 @@ import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { AppContext } from './AppContext';
 import GraphErrorModal from './components/Modals/GraphErrorModal';
 import MenuContainer from './components/Menu/MenuContainer';
+import QueryCustomCreate from './components/Float/QueryCustomCreate';
 
 const fullEdgeList = [
     'CanRDP',
@@ -216,6 +217,7 @@ export default class AppContainer extends Component {
                             <NodeEditor />
                             <HelpModal />
                             <GraphErrorModal />
+                            <QueryCustomCreate />
                         </div>
                     </AppContext.Provider>
                 </CSSTransition>

--- a/src/components/Float/QueryCustomCreate.jsx
+++ b/src/components/Float/QueryCustomCreate.jsx
@@ -168,7 +168,7 @@ const QueryCustomCreate = () => {
                                     onChange={setSingleSelections}
                                     options={categories}
                                     selected={singleSelections}
-                                    minLength={1}
+                                    maxHeight={100}
                                     onBlur={event => setSelectedCategory(event.target.defaultValue)}
                                 />
                             </Col>

--- a/src/components/Float/QueryCustomCreate.jsx
+++ b/src/components/Float/QueryCustomCreate.jsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useState, useContext } from 'react';
+import PropTypes from 'prop-types';
+import {
+    Panel,
+    Button,
+    FormControl,
+    ControlLabel,
+    FormGroup,
+    Form,
+    Col,
+    Checkbox,
+    Row
+} from 'react-bootstrap';
+import { Typeahead } from 'react-bootstrap-typeahead';
+import styles from './QueryCustomCreate.module.css';
+import Draggable from 'react-draggable';
+import clsx from 'clsx';
+import { AppContext } from '../../AppContext';
+import PoseContainer from '../PoseContainer';
+import { useDragControls } from 'framer-motion';
+
+import { remote } from 'electron';
+const { app } = remote;
+import path from 'path';
+import fs from 'fs';
+import { select } from 'async';
+
+const QueryCustomCreate = () => {
+    const [nodeCollapse, setNodeCollapse] = useState(appStore.performance.edge);
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState('');
+    const dragControl = useDragControls();
+    const [categories, setCategories] = useState([]);
+    const [singleSelections, setSingleSelections] = useState([]);
+    const [queryName, setQueryName] = useState('');
+    const [selectedCategory, setSelectedCategory] = useState('');
+
+    const context = useContext(AppContext);
+
+    const handleOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const changeNodeCollapse = (e) => {
+        let val = parseInt(e.target.value);
+        setNodeCollapse(val);
+        appStore.performance.edge = val;
+        conf.set('performance', appStore.performance);
+    };
+
+    const edgeLabelChange = (e) => {
+        let val = parseInt(e.target.value);
+        context.setEdgeLabels(val);
+    };
+
+    const nodeLabelChange = (e) => {
+        let val = parseInt(e.target.value);
+        context.setNodeLabels(val);
+    };
+
+    const onKeyDown = (e) => {
+        let key = e.keyCode ? e.keyCode : e.which;
+
+        if (key === 13) {
+            emitter.emit('query', query);
+        }
+    };
+
+    const runQuery = () => {
+        emitter.emit('query', query);
+    }
+
+    const saveQuery = () => {
+
+        let filePath = path.join(
+            app.getPath('userData'),
+            '/customqueries.json'
+        );
+
+        fs.readFile(filePath, 'utf8', (err, data) => {
+            let j = JSON.parse(data);
+            j.queries.push({ "name": queryName, "category": selectedCategory, "queryList": [{ "final": true, "query": query, "allowColapse": true }] })
+            fs.writeFile(filePath, JSON.stringify(j, null, "\t"), function (err) { emitter.emit('updateCustomQueries'); })
+        });
+
+        setSingleSelections([]);
+        setSelectedCategory('');
+        setQueryName('');
+        setQuery('');
+        handleClose();
+    };
+
+    const onChange = (e) => {
+        setQuery(e.target.value);
+    };
+
+    const registerCategories = (e) => {
+        let tempCategories = categories;
+        for (var queryCategory in e) {
+            if (['last', 'chunk', 'allEdgesSameType'].includes(queryCategory) || categories.includes(queryCategory)) {
+                continue;
+            }
+            tempCategories.push(queryCategory);
+        }
+        setCategories(tempCategories);
+    }
+
+    useEffect(() => {
+        emitter.on('openQueryCreate', handleOpen);
+        emitter.on('registerQueryCategories', registerCategories);
+        return () => {
+            emitter.removeListener('openQueryCreate', handleOpen);
+            emitter.removeListener('registerQueryCategories', registerCategories);
+        };
+    }, []);
+
+    return (
+        <PoseContainer
+            visible={open}
+            className={clsx(
+                styles.container,
+                context.darkMode ? styles.dark : null
+            )}
+            dragHandle={dragControl}
+        >
+            <Panel
+                style={{ width: "800px" }}
+            >
+                <Panel.Heading
+                    onMouseDown={(e) => {
+                        dragControl.start(e);
+                    }}
+                >
+                    Create Custom Query
+                    <Button
+                        onClick={handleClose}
+                        className='close'
+                        aria-label='close'
+                    >
+                        <span aria-hidden='true'>&times;</span>
+                    </Button>
+                </Panel.Heading>
+
+                <Panel.Body>
+                    <FormGroup>
+                        <Row>
+                            <Col componentClass={ControlLabel} sm={6}>
+                                <input
+                                    id='queryName'
+                                    type='text'
+                                    className={clsx(styles.input, 'form-control')}
+                                    value={queryName}
+                                    autoComplete='off'
+                                    placeholder='Name your query.'
+                                    onChange={event => setQueryName(event.target.value)}
+                                />
+                            </Col>
+                            <Col componentClass={ControlLabel} sm={1}>
+
+                            </Col>
+                            <Col componentClass={ControlLabel} sm={5}>
+                                <Typeahead
+                                    placeholder='Select query category'
+                                    onChange={setSingleSelections}
+                                    options={categories}
+                                    selected={singleSelections}
+                                    minLength={1}
+                                    onBlur={event => setSelectedCategory(event.target.defaultValue)}
+                                />
+                            </Col>
+                        </Row>
+                    </FormGroup>
+                    <FormGroup>
+                        <Row>
+                            <Col componentClass={ControlLabel} sm={11}>
+                                <input
+                                    type='text'
+                                    onKeyDown={onKeyDown}
+                                    onChange={onChange}
+                                    value={query}
+                                    className={clsx(styles.input, 'form-control')}
+                                    autoComplete='off'
+                                    placeholder='Enter a cypher query. Your query must return nodes or paths.'
+                                />
+                            </Col>
+                            <Col componentClass={ControlLabel} style={{ margin: "auto", cursor: "pointer"}} sm={1}>
+                                <i class="fa fa-play fa-2x" onClick={runQuery}></i>
+                            </Col>
+                        </Row>
+                    </FormGroup>
+                    <FormGroup>
+                        <Row>
+                            <Col componentClass={ControlLabel} sm={2}>
+                                <Button
+                                    onClick={handleClose}
+                                >
+                                    Cancel
+                                </Button>
+                            </Col>
+                            <Col componentClass={ControlLabel} sm={8}>
+
+                            </Col>
+                            <Col
+                                componentClass={ControlLabel}
+                                style={{"text-align": "right"}}
+                                sm={2}
+                            >
+                                <Button
+                                    onClick={saveQuery}
+                                >
+                                    Save
+                                </Button>
+                            </Col>
+                        </Row>
+                    </FormGroup>
+                </Panel.Body>
+            </Panel>
+        </PoseContainer>
+    );
+};
+
+QueryCustomCreate.propTypes = {};
+export default QueryCustomCreate;

--- a/src/components/Float/QueryCustomCreate.module.css
+++ b/src/components/Float/QueryCustomCreate.module.css
@@ -1,0 +1,138 @@
+.inputWidth {
+    width: 6ch;
+    margin-right: 5px;
+}
+
+.glyphMargin {
+    margin-left: 5px;
+}
+
+.container :global {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    overflow: hidden;
+    box-shadow: 0 5px 15px 0 black;
+}
+
+.container :global .panel {
+    margin-bottom: 0;
+    border: none;
+    overflow: hidden;
+}
+
+.container :global .panel-heading {
+    border: none;
+    border-top-right-radius: 10px;
+    border-top-left-radius: 10px;
+}
+
+.dark :global .panel-heading {
+    background: #444b55;
+    font-family: Helvetica;
+    font-size: 20px;
+    font-weight: 400;
+    color: white;
+}
+
+.dark :global .panel-body {
+    background: #151d29;
+    color: white;
+}
+
+.dark :global button.close {
+    opacity: 1;
+    background-color: 151d29;
+    color: white;
+}
+
+.dark :global select {
+    background-color: #444b55;
+    font-family: Helvetica;
+    color: white;
+    border: none;
+}
+
+.dark :global input {
+    background-color: #444b55;
+    font-family: Helvetica;
+    font-weight: 400;
+    color: white;
+    border: none;
+}
+
+label {
+    font-family: Helvetica;
+    font-weight: 400 !important;
+}
+
+/* Below adapted from https://stackoverflow.com/a/24465732 */
+
+#slider {
+    width: 400px;
+    height: 17px;
+    position: relative;
+    margin: 100px auto;
+    background: white;
+}
+
+#slider .bar {
+    width: 388px;
+    height: 5px;
+    background: #333;
+    position: relative;
+    top: 1px;
+    left: 1px;
+}
+
+#slider .highlight {
+    height: 2px;
+    position: absolute;
+    width: 388px;
+    top: 6px;
+    left: 6px;
+
+    -webkit-border-radius: 40px;
+    -moz-border-radius: 40px;
+    border-radius: 40px;
+
+    background: rgba(255, 255, 255, 0.25);
+}
+
+input[type='range'] {
+    -webkit-appearance: none;
+    background-color: #444b55;
+    height: 5px;
+    padding: 0px 0px;
+}
+
+input[type='range']::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    position: relative;
+    top: 0px;
+    z-index: 1;
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    -webkit-border-radius: 40px;
+    -moz-border-radius: 40px;
+    border-radius: 40px;
+    background-color: #4f80a1;
+}
+
+input[type='range']:hover ~ #rangevalue,
+input[type='range']:active ~ #rangevalue {
+    -ms-filter: 'progid:DXImageTransform.Microsoft.Alpha(Opacity=100)';
+    filter: alpha(opacity=100);
+    opacity: 1;
+    top: -75px;
+}
+
+input[type='range']:focus {
+    outline: none;
+}
+
+.slider {
+    top: 11px;
+}

--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.json
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.json
@@ -2,6 +2,7 @@
     "queries": [
         {
             "name": "Find all Domain Admins",
+            "category": "Domain Information",
             "queryList": [
                 {
                     "final": true,
@@ -14,26 +15,30 @@
             ]
         },
         {
-            "name": "Find Shortest Paths to Domain Admins",
+            "name": "Map Domain Trusts",
+            "category": "Domain Information",
             "queryList": [
                 {
-                    "final": false,
-                    "title": "Select a Domain Admin group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid =~ $name RETURN n.name ORDER BY n.name DESC",
-                    "props": {
-                        "name": "(?i)S-1-5-.*-512"
-                    }
-                },
+                    "final": true,
+                    "query": "MATCH p=(n:Domain)-->(m:Domain) RETURN p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Computers with Unsupported Operating Systems",
+            "category": "Domain Information",
+            "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH p=shortestPath((n)-[:{}*1..]->(m:Group {name:$result})) WHERE NOT n=m RETURN p",
-                    "allowCollapse": true,
-                    "endNode": "{}"
+                    "query": "MATCH (n:Computer) WHERE n.operatingsystem =~ \"(?i).*(2000|2003|2008|xp|vista|7|me).*\" RETURN n",
+                    "allowCollapse": true
                 }
             ]
         },
         {
             "name": "Find Principals with DCSync Rights",
+            "category": "Dangerous Rights",
             "queryList": [
                 {
                     "final": false,
@@ -50,6 +55,7 @@
         },
         {
             "name": "Users with Foreign Domain Group Membership",
+            "category": "Dangerous Rights",
             "queryList": [
                 {
                     "final": false,
@@ -66,6 +72,7 @@
         },
         {
             "name": "Groups with Foreign Domain Group Membership",
+            "category": "Dangerous Rights",
             "queryList": [
                 {
                     "final": false,
@@ -81,17 +88,159 @@
             ]
         },
         {
-            "name": "Map Domain Trusts",
+            "name": "Find Computers where Domain Users are Local Admin",
+            "category": "Dangerous Rights",
+            "queryList": [
+                {
+                    "final": false,
+                    "title": "Select a Domain Users Group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
+                },
+                {
+                    "final": true,
+                    "query": "MATCH p=(m:Group {name:$result})-[:AdminTo]->(n:Computer) RETURN p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Computers where Domain Users can read LAPS passwords",
+            "category": "Dangerous Rights",
+            "queryList": [
+                {
+                    "final": false,
+                    "title": "Select a Domain Users Group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH '-513' RETURN n.name ORDER BY n.name DESC"
+                },
+                {
+                    "final": true,
+                    "query": "MATCH p=(Group {name:$result})-[:MemberOf*0..]->(g:Group)-[:AllExtendedRights|ReadLAPSPassword]->(n:Computer) RETURN p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find All Paths from Domain Users to High Value Targets",
+            "category": "Dangerous Rights",
+            "queryList": [
+                {
+                    "final": false,
+                    "title": "Select a Domain Users Group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
+                },
+                {
+                    "final": true,
+                    "query": "MATCH p=shortestPath((g:Group {name:$result})-[*1..]->(n {highvalue:true})) WHERE g<>n return p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Workstations where Domain Users can RDP",
+            "category": "Dangerous Rights",
+            "queryList": [
+                {
+                    "final": false,
+                    "title": "Select a Domain Users Group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
+                },
+                {
+                    "final": true,
+                    "query": "match p=(g:Group {name:$result})-[:CanRDP]->(c:Computer) where NOT c.operatingsystem CONTAINS \"Server\" return p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Servers where Domain Users can RDP",
+            "category": "Dangerous Rights",
+            "queryList": [
+                {
+                    "final": false,
+                    "title": "Select a Domain Users Group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
+                },
+                {
+                    "final": true,
+                    "query": "MATCH p=(g:Group {name:$result})-[:CanRDP]->(c:Computer) WHERE c.operatingsystem CONTAINS \"Server\" return p",
+                    "allowCollapse": false
+                }
+            ]
+        },
+        {
+            "name": "Find Dangerous Rights for Domain Users Groups",
+            "category": "Dangerous Rights",
+            "queryList": [
+                {
+                    "final": false,
+                    "title": "Select a Domain Users Group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
+                },
+                {
+                    "final": true,
+                    "query": "MATCH p=(m:Group)-[:Owns|WriteDacl|GenericAll|WriteOwner|ExecuteDCOM|GenericWrite|AllowedToDelegate|ForceChangePassword]->(n:Computer) WHERE m.objectid ENDS WITH \"-513\" RETURN p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Domain Admin Logons to non-Domain Controllers",
+            "category": "Dangerous Rights",
             "queryList": [
                 {
                     "final": true,
-                    "query": "MATCH p=(n:Domain)-->(m:Domain) RETURN p",
+                    "query": "MATCH (dc)-[r:MemberOf*0..]->(g:Group) WHERE g.objectid ENDS WITH '-516' WITH COLLECT(dc) AS exclude MATCH p = (c:Computer)-[n:HasSession]->(u:User)-[r2:MemberOf*1..]->(g:Group) WHERE  g.objectid ENDS WITH '-512' AND NOT c IN exclude RETURN p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Kerberoastable Members of High Value Groups",
+            "category": "Kerberos Interaction",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group)) WHERE g.highvalue=true AND n.hasspn=true RETURN p",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "List all Kerberoastable Accounts",
+            "category": "Kerberos Interaction",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH (n:User)WHERE n.hasspn=true RETURN n",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find Kerberoastable Users with most privileges",
+            "category": "Kerberos Interaction",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH (u:User {hasspn:true}) OPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer) OPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer) WITH u,COLLECT(c1) + COLLECT(c2) AS tempVar UNWIND tempVar AS comps RETURN u.name,COUNT(DISTINCT(comps)) ORDER BY COUNT(DISTINCT(comps)) DESC",
+                    "allowCollapse": true
+                }
+            ]
+        },
+        {
+            "name": "Find AS-REP Roastable Users (DontReqPreAuth)",
+            "category": "Kerberos Interaction",
+            "queryList": [
+                {
+                    "final": true,
+                    "query": "MATCH (u:User {dontreqpreauth: true}) RETURN u",
                     "allowCollapse": true
                 }
             ]
         },
         {
             "name": "Shortest Paths to Unconstrained Delegation Systems",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": true,
@@ -101,6 +250,7 @@
         },
         {
             "name": "Shortest Paths from Kerberoastable Users",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
@@ -122,6 +272,7 @@
         },
         {
             "name": "Shortest Paths to Domain Admins from Kerberoastable Users",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
@@ -141,6 +292,7 @@
         },
         {
             "name": "Shortest Path from Owned Principals",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
@@ -162,6 +314,7 @@
         },
         {
             "name": "Shortest Paths to Domain Admins from Owned Principals",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
@@ -181,6 +334,7 @@
         },
         {
             "name": "Shortest Paths to High Value Targets",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
@@ -196,37 +350,8 @@
             ]
         },
         {
-            "name": "Find Computers where Domain Users are Local Admin",
-            "queryList": [
-                {
-                    "final": false,
-                    "title": "Select a Domain Users Group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
-                },
-                {
-                    "final": true,
-                    "query": "MATCH p=(m:Group {name:$result})-[:AdminTo]->(n:Computer) RETURN p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Computers where Domain Users can read LAPS passwords",
-            "queryList": [
-                {
-                    "final": false,
-                    "title": "Select a Domain Users Group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH '-513' RETURN n.name ORDER BY n.name DESC"
-                },
-                {
-                    "final": true,
-                    "query": "MATCH p=(Group {name:$result})-[:MemberOf*0..]->(g:Group)-[:AllExtendedRights|ReadLAPSPassword]->(n:Computer) RETURN p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
             "name": "Shortest Paths from Domain Users to High Value Targets",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
@@ -241,122 +366,22 @@
             ]
         },
         {
-            "name": "Find All Paths from Domain Users to High Value Targets",
+            "name": "Find Shortest Paths to Domain Admins",
+            "category": "Shortest Paths",
             "queryList": [
                 {
                     "final": false,
-                    "title": "Select a Domain Users Group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
+                    "title": "Select a Domain Admin group...",
+                    "query": "MATCH (n:Group) WHERE n.objectid =~ $name RETURN n.name ORDER BY n.name DESC",
+                    "props": {
+                        "name": "(?i)S-1-5-.*-512"
+                    }
                 },
                 {
                     "final": true,
-                    "query": "MATCH p=shortestPath((g:Group {name:$result})-[*1..]->(n {highvalue:true})) WHERE g<>n return p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Workstations where Domain Users can RDP",
-            "queryList": [
-                {
-                    "final": false,
-                    "title": "Select a Domain Users Group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
-                },
-                {
-                    "final": true,
-                    "query": "match p=(g:Group {name:$result})-[:CanRDP]->(c:Computer) where NOT c.operatingsystem CONTAINS \"Server\" return p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Servers where Domain Users can RDP",
-            "queryList": [
-                {
-                    "final": false,
-                    "title": "Select a Domain Users Group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
-                },
-                {
-                    "final": true,
-                    "query": "MATCH p=(g:Group {name:$result})-[:CanRDP]->(c:Computer) WHERE c.operatingsystem CONTAINS \"Server\" return p",
-                    "allowCollapse": false
-                }
-            ]
-        },
-        {
-            "name": "Find Dangerous Rights for Domain Users Groups",
-            "queryList": [
-                {
-                    "final": false,
-                    "title": "Select a Domain Users Group...",
-                    "query": "MATCH (n:Group) WHERE n.objectid ENDS WITH \"-513\" RETURN n.name ORDER BY n.name DESC"
-                },
-                {
-                    "final": true,
-                    "query": "MATCH p=(m:Group)-[:Owns|WriteDacl|GenericAll|WriteOwner|ExecuteDCOM|GenericWrite|AllowedToDelegate|ForceChangePassword]->(n:Computer) WHERE m.objectid ENDS WITH \"-513\" RETURN p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Kerberoastable Members of High Value Groups",
-            "queryList": [
-                {
-                    "final": true,
-                    "query": "MATCH p=shortestPath((n:User)-[:MemberOf]->(g:Group)) WHERE g.highvalue=true AND n.hasspn=true RETURN p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "List all Kerberoastable Accounts",
-            "queryList": [
-                {
-                    "final": true,
-                    "query": "MATCH (n:User)WHERE n.hasspn=true RETURN n",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Kerberoastable Users with most privileges",
-            "queryList": [
-                {
-                    "final": true,
-                    "query": "MATCH (u:User {hasspn:true}) OPTIONAL MATCH (u)-[:AdminTo]->(c1:Computer) OPTIONAL MATCH (u)-[:MemberOf*1..]->(:Group)-[:AdminTo]->(c2:Computer) WITH u,COLLECT(c1) + COLLECT(c2) AS tempVar UNWIND tempVar AS comps RETURN u.name,COUNT(DISTINCT(comps)) ORDER BY COUNT(DISTINCT(comps)) DESC",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Domain Admin Logons to non-Domain Controllers",
-            "queryList": [
-                {
-                    "final": true,
-                    "query": "MATCH (dc)-[r:MemberOf*0..]->(g:Group) WHERE g.objectid ENDS WITH '-516' WITH COLLECT(dc) AS exclude MATCH p = (c:Computer)-[n:HasSession]->(u:User)-[r2:MemberOf*1..]->(g:Group) WHERE  g.objectid ENDS WITH '-512' AND NOT c IN exclude RETURN p",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find Computers with Unsupported Operating Systems",
-            "queryList": [
-                {
-                    "final": true,
-                    "query": "MATCH (n:Computer) WHERE n.operatingsystem =~ \"(?i).*(2000|2003|2008|xp|vista|7|me).*\" RETURN n",
-                    "allowCollapse": true
-                }
-            ]
-        },
-        {
-            "name": "Find AS-REP Roastable Users (DontReqPreAuth)",
-            "queryList": [
-                {
-                    "final": true,
-                    "query": "MATCH (u:User {dontreqpreauth: true}) RETURN u",
-                    "allowCollapse": true
+                    "query": "MATCH p=shortestPath((n)-[:{}*1..]->(m:Group {name:$result})) WHERE NOT n=m RETURN p",
+                    "allowCollapse": true,
+                    "endNode": "{}"
                 }
             ]
         }

--- a/src/components/SearchContainer/Tabs/PrebuiltQueries.module.css
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueries.module.css
@@ -5,3 +5,132 @@
 .dark h3 {
     color: white;
 }
+
+    .dark :global .table {
+        background-color: #151d29;
+        border-left: solid #151d29 0px;
+        border-right: solid #151d29 0px;
+        border-top: solid #151d29 0px;
+    }
+
+.dark {
+    background-color: #151d29;
+    border-left: solid #151d29 0px;
+    border-right: solid #151d29 0px;
+}
+
+.light {
+    box-shadow: 0 4px 9px 0 rgba(0, 0, 0, 0.2);
+    border-radius: 11px;
+    border-radius: 11px;
+}
+
+.itemlist {
+    overflow-y: auto;
+    overflow-x: hidden;
+    margin-bottom: 5px;
+    margin-top: 5px;
+    margin-left: 10px;
+    margin-right: 10px;
+}
+
+    .itemlist :global table {
+        margin-bottom: 0px;
+        margin-top: 0px;
+    }
+
+        .itemlist :global table > thead {
+            text-align: left;
+            position: -webkit-sticky;
+            position: sticky;
+        }
+
+        .itemlist :global table > tbody > tr {
+            font-family: Helvetica;
+            font-size: 12px;
+            border-style: 0px solid;
+        }
+
+            .itemlist :global table > tbody > tr > td:nth-of-type(1) {
+                border-bottom: 1px solid #94989d;
+                border-top: 0px solid;
+            }
+
+.light :global table > tbody > tr > td:nth-of-type(1) {
+    border-bottom: 1px solid #94989d;
+}
+
+.itemlist :global table > tbody > tr:last-child > td {
+    border-bottom: 0px solid;
+    border-top: 0px solid;
+}
+
+.itemlist :global table > tbody > tr > td {
+    border-top: 0px solid;
+}
+
+.dark :global table > tbody > tr > td {
+    border-bottom: 1px solid #94989d;
+}
+
+.light :global table > tbody > tr > td {
+    border-bottom: 1px solid #94989d;
+}
+
+.dark :global table > tbody > tr:hover {
+    background-color: #0d1013;
+}
+
+.dark :global table > tbody > tr:hover {
+    background-color: #406f8e;
+}
+
+.dark :global table > tbody > tr {
+    opacity: 0.72;
+    background-color: #2b333e;
+}
+
+.light :global table > tbody > tr {
+    background-color: #e7e7e7;
+    opacity: 0.87;
+}
+
+.light table > tbody > tr td:nth-of-type(1) {
+    color: #1d2735;
+}
+
+.light table > tbody > tr td:nth-of-type(2) {
+    color: #1d2735;
+    font-weight: bold;
+}
+
+hr {
+    border-color: #94989d;
+}
+
+.dl {
+    margin-right: 0px;
+}
+
+    .dl > h5 {
+        margin-top: 10px;
+        margin-bottom: 5px;
+        padding-right: 10px;
+        padding-left: 10px;
+        font-size: 18px;
+        font-family: Helvetica;
+        font-weight: bold;
+    }
+
+.dark > .dl > h5 {
+    color: white !important;
+}
+
+.light > .dl > h5 {
+    color: black;
+}
+
+.dark .itemlist td {
+    color: white;
+    opacity: 1;
+}

--- a/src/components/SearchContainer/Tabs/PrebuiltQueriesDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueriesDisplay.jsx
@@ -34,8 +34,11 @@ const PrebuiltQueriesDisplay = () => {
             var y = [];
             j.queries.forEach((query) => {
                 try {
-                    if (query.category === undefined) {
+                    if (query.category === undefined || query.category === "") {
                         query.category = "Uncategorized Query";
+                    }
+                    if (query.name === "") {
+                        query.name = "Unnamed Query"
                     }
                     if (!(query.category in y)) {
                             y[query.category] = [];
@@ -60,8 +63,11 @@ const PrebuiltQueriesDisplay = () => {
 
                 $.each(response.queries, function (_, el) {
                     try {
-                        if (el.category === undefined) {
+                        if (el.category === undefined || el.category === "") {
                             el.category = "Uncategorized Query";
+                        }
+                        if (el.name === "") {
+                            el.name = "Unnamed Query"
                         }
                         if (!(el.category in y)) {
                             y[el.category] = [];

--- a/src/components/SearchContainer/Tabs/PrebuiltQueryNode.jsx
+++ b/src/components/SearchContainer/Tabs/PrebuiltQueryNode.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import './PrebuiltQueries.module.css';
 
 export default class PrebuiltQueryNode extends Component {
     render() {
@@ -14,12 +15,10 @@ export default class PrebuiltQueryNode extends Component {
         }.bind(this);
 
         return (
-            <div>
-                <a href='#' onClick={c}>
-                    {this.props.info.name}
-                </a>
-                <br />
-            </div>
+                <tr style={{ cursor: 'pointer' }} onClick={c}>
+                    <td align='left'>{this.props.info.name}</td>
+                    <td align='right'></td>
+                </tr>
         );
     }
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -850,3 +850,204 @@ div.tooltip-inner-custom {
     opacity: 1;
     background-color: #383332;
 }
+
+.rbt .rbt-input-main::-ms-clear {
+    display: none;
+}
+
+/**
+ * Menu
+ */
+.rbt-menu {
+    margin-bottom: 2px;
+}
+
+    .rbt-menu > .dropdown-item {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+        .rbt-menu > .dropdown-item:focus {
+            outline: none;
+        }
+
+.rbt-menu-pagination-option {
+    text-align: center;
+}
+
+/**
+ * Multi-select Input
+ */
+.rbt-input-multi {
+    cursor: text;
+    overflow: hidden;
+    position: relative;
+}
+
+    .rbt-input-multi.focus {
+        border-color: #80bdff;
+        box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
+        color: #495057;
+        outline: 0;
+    }
+
+    .rbt-input-multi.form-control {
+        height: auto;
+    }
+
+        .rbt-input-multi.form-control[disabled] {
+            background-color: #e9ecef;
+            opacity: 1;
+        }
+
+    .rbt-input-multi.is-invalid.focus {
+        border-color: #dc3545;
+        box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);
+    }
+
+    .rbt-input-multi.is-valid.focus {
+        border-color: #28a745;
+        box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
+    }
+
+    .rbt-input-multi input::-moz-placeholder {
+        color: #6c757d;
+        opacity: 1;
+    }
+
+    .rbt-input-multi input:-ms-input-placeholder {
+        color: #6c757d;
+    }
+
+    .rbt-input-multi input::-webkit-input-placeholder {
+        color: #6c757d;
+    }
+
+    .rbt-input-multi .rbt-input-wrapper {
+        align-items: flex-start;
+        display: flex;
+        flex-wrap: wrap;
+        margin-bottom: -4px;
+        margin-top: -1px;
+        overflow: hidden;
+    }
+
+    .rbt-input-multi .rbt-input-main {
+        margin: 1px 0 4px;
+    }
+
+/**
+ * Close Button
+ */
+.rbt-close {
+    z-index: 1;
+}
+
+.rbt-close-lg {
+    font-size: 24px;
+}
+
+/**
+ * Token
+ */
+.rbt-token {
+    background-color: #e7f4ff;
+    border: 0;
+    border-radius: 0.25rem;
+    color: #007bff;
+    display: inline-block;
+    line-height: 1em;
+    margin: 1px 3px 2px 0;
+    padding: 4px 7px;
+    position: relative;
+}
+
+.rbt-token-disabled {
+    background-color: rgba(0, 0, 0, 0.1);
+    color: #495057;
+    pointer-events: none;
+}
+
+.rbt-token-removeable {
+    cursor: pointer;
+    padding-right: 21px;
+}
+
+.rbt-token-active {
+    background-color: #007bff;
+    color: #fff;
+    outline: none;
+    text-decoration: none;
+}
+
+.rbt-token .rbt-token-remove-button {
+    bottom: 0;
+    color: inherit;
+    font-size: inherit;
+    font-weight: normal;
+    opacity: 1;
+    outline: none;
+    padding: 3px 7px;
+    position: absolute;
+    right: 0;
+    text-shadow: none;
+    top: -2px;
+}
+
+/**
+ * Loader + CloseButton container
+ */
+.rbt-aux {
+    align-items: center;
+    display: flex;
+    bottom: 0;
+    justify-content: center;
+    pointer-events: none;
+    /* Don't block clicks on the input */
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 34px;
+}
+
+.rbt-aux-lg {
+    width: 46px;
+}
+
+.rbt-aux .rbt-close {
+    margin-top: -4px;
+    pointer-events: auto;
+    /* Override pointer-events: none; above */
+}
+
+.has-aux .rbt-input {
+    padding-right: 34px;
+}
+
+.rbt-highlight-text {
+    background-color: inherit;
+    color: inherit;
+    font-weight: bold;
+    padding: 0;
+}
+
+/**
+ * Input Groups
+ */
+.input-group > .rbt {
+    flex: 1;
+}
+
+    .input-group > .rbt .rbt-input-hint, .input-group > .rbt .rbt-aux {
+        z-index: 5;
+    }
+
+    .input-group > .rbt:not(:first-child) .form-control {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
+    .input-group > .rbt:not(:last-child) .form-control {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }


### PR DESCRIPTION
## **Category based query listing**
Through the usage of the already existing CollapsibleSection elements, alteration of the PrebuiltQueryNode element, the creation of the new JSON query "category" value and rework of the "PrebuiltQueriesDisplay.jsx" code, my intention with this is to present the queries on an organized fashion, instead of the simple unformatted list it currently is. These allow users to encounter the queries they are searching for faster than before, as the new categories I've added to the prebuilt queries limit the "table" size where they have to look for it. Additionally, the usage of already existing JSX Elements like CollapsibleSection not only ties it down with the other tabs, creating a more uniform design, but also accounts for both light and dark themes.
Since this logic depends on an arbitrary categorization registered on the JSON query object, it can only occur whenever the "category" value is defined. If a query is created either on "customqueries.json" or "PrebuiltQueries.json" without a category, it will be displayed under the "Uncategorized Query" collapsible section - I thought about using only "Uncategorized", but it resembles JavaScript's undefined a bit too much and users might think it's broken code.
   
For the sake of demonstration, here's a before and after on the JSON object:

**Before**
```
{
	"name": "Find Principals with DCSync Rights",
	"queryList": [
               ...
	]
}
```
**After**
```
{
	"name": "Find Principals with DCSync Rights",
	"category": "Dangerous Rights",
	"queryList": [
               ...
	]
}
```

Here's how it looks now:

![image](https://user-images.githubusercontent.com/21147974/129476286-87dac82f-4f09-4c96-9dc5-b9f27eb66409.png)

The category names are completely custom and simply have to be changed on the "PrebuiltQueries.json" if you guys feel like naming it something else or creating different categories altogether.

---

## **In-app create custom query**
To incentivize users to explore the creation of custom queries in order to achieve new exploitation paths and advanced node filtering, I've created a floating form - similar to the settings modal - where a new query can be crafted interactively. This not only allows for real-time integrated testing, but also allows for a seamless interaction without having to leave the window.
This form is not intended to fulfill every custom query creation necessity, as it only accounts for simple single queries. Complex chained queries still require users to edit the JSON files manually.
Here's how it looks:

![image](https://user-images.githubusercontent.com/21147974/129476417-0e1d03b8-db32-4eb8-97ee-7b4db6891da9.png)
