### PR TITLE
Add backup operators group to high value sids

### DIFF
--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -383,7 +383,7 @@ const MenuContainer = () => {
         setNeedsPostProcess(false)
         let session = driver.session();
 
-        const highValueSids = ["-544", "-500", "-512", "-516", "-518", "-519", "1-5-9", "-526", "-527"]
+        const highValueSids = ["-544", "-500", "-512", "-516", "-518", "-519", "1-5-9", "-526", "-527", "-551"]
         const highValueStatement = "UNWIND $sids AS sid MATCH (n:Base) WHERE n.objectid ENDS WITH sid SET n.highvalue=true"
 
         await session.run(highValueStatement, {sids: highValueSids}).catch((err) => {


### PR DESCRIPTION
Hello,

In this PR I've added the SID S-1-5-32-551 aka Backup Operators to High value by default.

https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/security-identifiers

Members of this group can dump remotely the sam/security/system files of the domain controller and therefore dcsync the domain, become domain admins etc. If you compromise one member of this group, you are one step closer to become DA.

You can find more information and demo on this poc for Windows and for Linux : 

https://github.com/mpgn/BackupOperatorToDA
https://github.com/horizon3ai/backup_dc_registry

![img](https://user-images.githubusercontent.com/5891788/154149582-42652915-57bd-436d-94b6-442aec6288b6.png)