### PR TITLE
Constrained Delegation Edge Fix

### DIFF
--- a/src/js/newingestion.js
+++ b/src/js/newingestion.js
@@ -110,7 +110,7 @@ export function buildComputerJsonNew(chunk) {
         format = [LABEL_COMPUTER, LABEL_COMPUTER, EDGE_ALLOWED_TO_DELEGATE, NON_ACL_PROPS];
 
         let props = allowedToDelegate.map((delegate) => {
-            return { source: identifier, target: delegate };
+            return { source: identifier, target: delegate.ObjectIdentifier };
         });
 
         insertNew(queries, format, props);
@@ -225,7 +225,7 @@ export function buildUserJsonNew(chunk) {
 
         format = [LABEL_USER, LABEL_COMPUTER, EDGE_ALLOWED_TO_DELEGATE, NON_ACL_PROPS];
         let props = allowedToDelegate.map((principal) => {
-            return { source: identifier, target: principal };
+            return { source: identifier, target: principal.ObjectIdentifier };
         });
 
         insertNew(queries, format, props);


### PR DESCRIPTION
The AllowedToDelegate edge did not appear to be working for me in my testing environment, with known constrained delegation relationships not showing up in the attack paths graph. Making the included small update to the ingestion code fixed this so that the edge appropriately displayed.  Data was initially collected with the newest version of SH, and I built BH from source when performing initial troubleshooting.