### PR TITLE
Convert remaining help texts to JSX

### DIFF
--- a/src/components/Modals/HelpTexts/AZAddSecret/AZAddSecret.jsx
+++ b/src/components/Modals/HelpTexts/AZAddSecret/AZAddSecret.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZAddSecret = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZAddSecret = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZAddSecret/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZAddSecret/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZAddSecret/General.jsx
+++ b/src/components/Modals/HelpTexts/AZAddSecret/General.jsx
@@ -1,11 +1,25 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = `Azure provides several systems and mechanisms for granting control of securable objects within Azure Active Directory, including tenant-scoped admin roles, object-scoped admin roles, explicit object ownership, and API permissions.
-
-    When a principal has been granted "Cloud App Admin" or "App Admin" against the tenant, that principal gains the ability to add new secrets to all Service Principals and App Registrations. Additionally, a principal that has been granted "Cloud App Admin" or "App Admin" against, or explicit ownership of a Service Principal or App Registration gains the ability to add secrets to that particular object.
-    `;
-    return { __html: text };
+const General = () => {
+    return (
+        <>
+            <p>
+                Azure provides several systems and mechanisms for granting
+                control of securable objects within Azure Active Directory,
+                including tenant-scoped admin roles, object-scoped admin roles,
+                explicit object ownership, and API permissions.
+            </p>
+            <p>
+                When a principal has been granted "Cloud App Admin" or "App
+                Admin" against the tenant, that principal gains the ability to
+                add new secrets to all Service Principals and App Registrations.
+                Additionally, a principal that has been granted "Cloud App
+                Admin" or "App Admin" against, or explicit ownership of a
+                Service Principal or App Registration gains the ability to add
+                secrets to that particular object.
+            </p>
+        </>
+    );
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZAddSecret/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZAddSecret/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZAddSecret/References.jsx
+++ b/src/components/Modals/HelpTexts/AZAddSecret/References.jsx
@@ -1,8 +1,22 @@
+import React from 'react';
+
 const References = () => {
-    let text = `<a href="https://attack.mitre.org/techniques/T1098/">ATT&CK T1098: Account Manipulation</a>
-    <a href="https://posts.specterops.io/azure-privilege-escalation-via-service-principal-abuse-210ae2be2a5">Andy Robbins - Azure Privilege Escalation via Service Principal Abuse</a>
-    <a href="https://docs.microsoft.com/en-us/azure/active-directory/roles/assign-roles-different-scopes">Assign Azure AD roles at different scopes</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://attack.mitre.org/techniques/T1098/'>
+                ATT&amp;CK T1098: Account Manipulation
+            </a>
+            <br />
+            <a href='https://posts.specterops.io/azure-privilege-escalation-via-service-principal-abuse-210ae2be2a5'>
+                Andy Robbins - Azure Privilege Escalation via Service Principal
+                Abuse
+            </a>
+            <br />
+            <a href='https://docs.microsoft.com/en-us/azure/active-directory/roles/assign-roles-different-scopes'>
+                Assign Azure AD roles at different scopes
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZAvereContributor/AZAvereContributor.jsx
+++ b/src/components/Modals/HelpTexts/AZAvereContributor/AZAvereContributor.jsx
@@ -14,36 +14,18 @@ const AZAvereContributor = ({
 }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZAvereContributor/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZAvereContributor/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZAvereContributor/General.jsx
+++ b/src/components/Modals/HelpTexts/AZAvereContributor/General.jsx
@@ -1,6 +1,13 @@
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = `Any principal granted the Avere Contributor role, scoped to the affected VM, can reset the built-in administrator password on the VM.`;
-    return { __html: text };
+import React from 'react';
+
+const General = () => {
+    return (
+        <p>
+            Any principal granted the Avere Contributor role, scoped to the
+            affected VM, can reset the built-in administrator password on the
+            VM.
+        </p>
+    );
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZAvereContributor/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZAvereContributor/Opsec.jsx
@@ -1,6 +1,12 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = `Azure will log each password reset event, including who performed the reset, against which account, and at what date and time.`;
-    return { __html: text };
+    return (
+        <p>
+            Azure will log each password reset event, including who performed
+            the reset, against which account, and at what date and time.
+        </p>
+    );
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZAvereContributor/References.jsx
+++ b/src/components/Modals/HelpTexts/AZAvereContributor/References.jsx
@@ -1,8 +1,21 @@
+import React from 'react';
+
 const References = () => {
-    let text = `<a href="https://attack.mitre.org/tactics/TA0008/">ATT&CK T0008: Lateral Movement</a>
-    <a href="https://attack.mitre.org/techniques/T1021/">ATT&CK T1021: Remote Services</a>
-    <a href="https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#avere-contributor">Microsoft Docs - Avere Contributor</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://attack.mitre.org/tactics/TA0008/'>
+                ATT&amp;CK T0008: Lateral Movement
+            </a>
+            <br />
+            <a href='https://attack.mitre.org/techniques/T1021/'>
+                ATT&amp;CK T1021: Remote Services
+            </a>
+            <br />
+            <a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#avere-contributor'>
+                Microsoft Docs - Avere Contributor
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZExecuteCommand/AZExecuteCommand.jsx
+++ b/src/components/Modals/HelpTexts/AZExecuteCommand/AZExecuteCommand.jsx
@@ -14,36 +14,18 @@ const AZExecuteCommand = ({
 }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZExecuteCommand/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZExecuteCommand/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZExecuteCommand/General.jsx
+++ b/src/components/Modals/HelpTexts/AZExecuteCommand/General.jsx
@@ -1,8 +1,7 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+const General = () => {
+    return <></>;
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZExecuteCommand/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZExecuteCommand/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZExecuteCommand/References.jsx
+++ b/src/components/Modals/HelpTexts/AZExecuteCommand/References.jsx
@@ -1,8 +1,17 @@
+import React from 'react';
+
 const References = () => {
-    let text = `
-    <a href="https://attack.mitre.org/tactics/TA0002/">MITRE: Execution</a>
-    <a href="https://blog.netspi.com/attacking-azure-with-custom-script-extensions/">Attacking Azure with custom script extensions</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://attack.mitre.org/tactics/TA0002/'>
+                MITRE: Execution
+            </a>
+            <br />
+            <a href='https://blog.netspi.com/attacking-azure-with-custom-script-extensions/'>
+                Attacking Azure with custom script extensions
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZGrant/AZGrant.jsx
+++ b/src/components/Modals/HelpTexts/AZGrant/AZGrant.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZGrant = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZGrant = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZGrant/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZGrant/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZGrant/General.jsx
+++ b/src/components/Modals/HelpTexts/AZGrant/General.jsx
@@ -1,8 +1,7 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+const General = () => {
+    return <></>;
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZGrant/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZGrant/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZGrant/References.jsx
+++ b/src/components/Modals/HelpTexts/AZGrant/References.jsx
@@ -1,10 +1,22 @@
+import React from 'react';
+
 const References = () => {
-    let text = `
-    <a href="https://attack.mitre.org/techniques/T1098/">ATT&CK T1098: Account Manipulation</a>
-    <a href="https://medium.com/p/74aee1006f48">Andy Robbins - Azure Privilege Escalation via Azure API Permissions Abuse</a>
-    <a href="https://docs.microsoft.com/en-us/graph/permissions-reference">Microsoft Graph Permission Reference</a>`
-    ;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://attack.mitre.org/techniques/T1098/'>
+                ATT&amp;CK T1098: Account Manipulation
+            </a>
+            <br />
+            <a href='https://medium.com/p/74aee1006f48'>
+                Andy Robbins - Azure Privilege Escalation via Azure API
+                Permissions Abuse
+            </a>
+            <br />
+            <a href='https://docs.microsoft.com/en-us/graph/permissions-reference'>
+                Microsoft Graph Permission Reference
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZGrantSelf/AZGrantSelf.jsx
+++ b/src/components/Modals/HelpTexts/AZGrantSelf/AZGrantSelf.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZGrantSelf = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZGrantSelf = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZGrantSelf/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZGrantSelf/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZGrantSelf/General.jsx
+++ b/src/components/Modals/HelpTexts/AZGrantSelf/General.jsx
@@ -1,8 +1,7 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+const General = () => {
+    return <></>;
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZGrantSelf/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZGrantSelf/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZGrantSelf/References.jsx
+++ b/src/components/Modals/HelpTexts/AZGrantSelf/References.jsx
@@ -1,10 +1,22 @@
+import React from 'react';
+
 const References = () => {
-    let text = `
-    <a href="https://attack.mitre.org/techniques/T1098/">ATT&CK T1098: Account Manipulation</a>
-    <a href="https://medium.com/p/74aee1006f48">Andy Robbins - Azure Privilege Escalation via Azure API Permissions Abuse</a>
-    <a href="https://docs.microsoft.com/en-us/graph/permissions-reference">Microsoft Graph Permission Reference</a>`
-   ;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://attack.mitre.org/techniques/T1098/'>
+                ATT&amp;CK T1098: Account Manipulation
+            </a>
+            <br />
+            <a href='https://medium.com/p/74aee1006f48'>
+                Andy Robbins - Azure Privilege Escalation via Azure API
+                Permissions Abuse
+            </a>
+            <br />
+            <a href='https://docs.microsoft.com/en-us/graph/permissions-reference'>
+                Microsoft Graph Permission Reference
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZHasRole/AZHasRole.jsx
+++ b/src/components/Modals/HelpTexts/AZHasRole/AZHasRole.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZHasRole = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZHasRole = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZHasRole/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZHasRole/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZHasRole/General.jsx
+++ b/src/components/Modals/HelpTexts/AZHasRole/General.jsx
@@ -1,8 +1,7 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+const General = () => {
+    return <></>;
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZHasRole/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZHasRole/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZHasRole/References.jsx
+++ b/src/components/Modals/HelpTexts/AZHasRole/References.jsx
@@ -1,7 +1,17 @@
+import React from 'react';
+
 const References = () => {
-    let text = `<a href="https://docs.microsoft.com/en-us/graph/permissions-reference">Microsoft Graph Permission Reference</a>
-    <a href="https://docs.microsoft.com/en-us/azure/role-based-access-control/overview">Azure role-based access control</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://docs.microsoft.com/en-us/graph/permissions-reference'>
+                Microsoft Graph Permission Reference
+            </a>
+            <br />
+            <a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/overview'>
+                Azure role-based access control
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZMemberOf/AZMemberOf.jsx
+++ b/src/components/Modals/HelpTexts/AZMemberOf/AZMemberOf.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZMemberOf = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZMemberOf = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZMemberOf/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZMemberOf/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZMemberOf/General.jsx
+++ b/src/components/Modals/HelpTexts/AZMemberOf/General.jsx
@@ -1,8 +1,7 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+const General = () => {
+    return <></>;
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZMemberOf/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZMemberOf/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZMemberOf/References.jsx
+++ b/src/components/Modals/HelpTexts/AZMemberOf/References.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const References = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZOwner/AZOwner.jsx
+++ b/src/components/Modals/HelpTexts/AZOwner/AZOwner.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZOwner = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZOwner = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZOwner/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZOwner/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZOwner/General.jsx
+++ b/src/components/Modals/HelpTexts/AZOwner/General.jsx
@@ -1,6 +1,12 @@
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = `Object ownership means almost all abuses are possible against the target object.`;
-    return { __html: text };
+import React from 'react';
+
+const General = () => {
+    return (
+        <p>
+            Object ownership means almost all abuses are possible against the
+            target object.
+        </p>
+    );
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZOwner/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZOwner/Opsec.jsx
@@ -1,6 +1,12 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = `This depends on which abuse you perform, but in general Azure will create a log for each abuse action.`;
-    return { __html: text };
+    return (
+        <p>
+            This depends on which abuse you perform, but in general Azure will
+            create a log for each abuse action.
+        </p>
+    );
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZOwner/References.jsx
+++ b/src/components/Modals/HelpTexts/AZOwner/References.jsx
@@ -1,7 +1,17 @@
+import React from 'react';
+
 const References = () => {
-    let text = `<a href="https://blog.netspi.com/attacking-azure-with-custom-script-extensions/">Attacking Azure with custom script extensions</a>
-    <a href="https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner">Azure role-based access control - Owner</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://blog.netspi.com/attacking-azure-with-custom-script-extensions/'>
+                Attacking Azure with custom script extensions
+            </a>
+            <br />
+            <a href='https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#owner'>
+                Azure role-based access control - Owner
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/AZVMAdminLogin/AZVMAdminLogin.jsx
+++ b/src/components/Modals/HelpTexts/AZVMAdminLogin/AZVMAdminLogin.jsx
@@ -6,44 +6,21 @@ import Abuse from './Abuse';
 import Opsec from './Opsec';
 import References from './References';
 
-const AZVMAdminLogin = ({
-    sourceName,
-    sourceType,
-    targetName,
-    targetType,
-}) => {
+const AZVMAdminLogin = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/AZVMAdminLogin/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AZVMAdminLogin/Abuse.jsx
@@ -1,6 +1,7 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = ``;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return <></>;
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/AZVMAdminLogin/General.jsx
+++ b/src/components/Modals/HelpTexts/AZVMAdminLogin/General.jsx
@@ -1,10 +1,22 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = `When a virtual machine is configured to allow logon with Azure AD credentials, the VM automatically has certain principals added to its local administrators group, including any principal granted the Virtual Machine Administrator Login (or "VMAL") admin role.
-    
-    Any principal granted this role, scoped to the affected VM, can connect to the VM via RDP and will be granted local admin rights on the VM.`;
-    return { __html: text };
+const General = () => {
+    return (
+        <>
+            <p>
+                When a virtual machine is configured to allow logon with Azure
+                AD credentials, the VM automatically has certain principals
+                added to its local administrators group, including any principal
+                granted the Virtual Machine Administrator Login (or "VMAL")
+                admin role.
+            </p>
+            <p>
+                Any principal granted this role, scoped to the affected VM, can
+                connect to the VM via RDP and will be granted local admin rights
+                on the VM.
+            </p>
+        </>
+    );
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/AZVMAdminLogin/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/AZVMAdminLogin/Opsec.jsx
@@ -1,6 +1,7 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = ``;
-    return { __html: text };
+    return <></>;
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/AZVMAdminLogin/References.jsx
+++ b/src/components/Modals/HelpTexts/AZVMAdminLogin/References.jsx
@@ -1,8 +1,20 @@
+import React from 'react';
+
 const References = () => {
-    let text = `<a href="https://attack.mitre.org/tactics/TA0008/">ATT&CK T0008: Lateral Movement</a>
-    <a href="https://attack.mitre.org/techniques/T1021/">ATT&CK T1021: Remote Services</a>
-    <a href="https://docs.microsoft.com/en-us/azure/active-directory/devices/howto-vm-sign-in-azure-ad-windows">Login to Windows virtual machine in Azure using Azure Active Directory authentication</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://attack.mitre.org/tactics/TA0008/'>
+                ATT&amp;CK T0008: Lateral Movement
+            </a>
+            <a href='https://attack.mitre.org/techniques/T1021/'>
+                ATT&amp;CK T1021: Remote Services
+            </a>
+            <a href='https://docs.microsoft.com/en-us/azure/active-directory/devices/howto-vm-sign-in-azure-ad-windows'>
+                Login to Windows virtual machine in Azure using Azure Active
+                Directory authentication
+            </a>
+        </>
+    );
 };
 
 export default References;

--- a/src/components/Modals/HelpTexts/DCSync/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/Abuse.jsx
@@ -1,10 +1,26 @@
-const Abuse = (sourceName, sourceType, targetName, targetType) => {
-    let text = `You may perform a dcsync attack to get the password hash of an arbitrary principal using mimikatz:
-            
-            <code>lsadump::dcsync /domain:testlab.local /user:Administrator</code>
-            
-            You can also perform the more complicated ExtraSids attack to hop domain trusts. For information on this see the blog post by harmj0y in the references tab.`;
-    return { __html: text };
+import React from 'react';
+
+const Abuse = () => {
+    return (
+        <>
+            <p>
+                You may perform a dcsync attack to get the password hash of an
+                arbitrary principal using mimikatz:
+            </p>
+            <pre>
+                <code>
+                    {
+                        'lsadump::dcsync /domain:testlab.local /user:Administrator'
+                    }
+                </code>
+            </pre>
+            <p>
+                You can also perform the more complicated ExtraSids attack to
+                hop domain trusts. For information on this see the blog post by
+                harmj0y in the references tab.
+            </p>
+        </>
+    );
 };
 
 export default Abuse;

--- a/src/components/Modals/HelpTexts/DCSync/DCSync.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/DCSync.jsx
@@ -9,36 +9,22 @@ import References from './References';
 const DCSync = ({ sourceName, sourceType, targetName, targetType }) => {
     return (
         <Tabs defaultActiveKey={1} id='help-tab-container' justified>
-            <Tab
-                eventKey={1}
-                title='Info'
-                dangerouslySetInnerHTML={General(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={2}
-                title='Abuse Info'
-                dangerouslySetInnerHTML={Abuse(
-                    sourceName,
-                    sourceType,
-                    targetName,
-                    targetType
-                )}
-            />
-            <Tab
-                eventKey={3}
-                title='Opsec Considerations'
-                dangerouslySetInnerHTML={Opsec()}
-            />
-            <Tab
-                eventKey={4}
-                title='References'
-                dangerouslySetInnerHTML={References()}
-            />
+            <Tab eventKey={1} title='Info'>
+                <General
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetName={targetName}
+                />
+            </Tab>
+            <Tab eventKey={2} title='Abuse Info'>
+                <Abuse />
+            </Tab>
+            <Tab eventKey={3} title='Opsec Considerations'>
+                <Opsec />
+            </Tab>
+            <Tab eventKey={4} title='References'>
+                <References />
+            </Tab>
         </Tabs>
     );
 };

--- a/src/components/Modals/HelpTexts/DCSync/General.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/General.jsx
@@ -1,13 +1,28 @@
-import { groupSpecialFormat} from '../Formatter';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { groupSpecialFormat } from '../Formatter';
 
-const General = (sourceName, sourceType, targetName, targetType) => {
-    let text = `${groupSpecialFormat(
-        sourceType,
-        sourceName
-    )} the DS-Replication-Get-Changes and the DS-Replication-Get-Changes-All privilege on the domain ${targetName}.
-    
-    These two privileges allow a principal to perform a DCSync attack.`;
-    return { __html: text };
+const General = ({ sourceName, sourceType, targetName }) => {
+    return (
+        <>
+            <p>
+                {groupSpecialFormat(sourceType, sourceName)} the
+                DS-Replication-Get-Changes and the
+                DS-Replication-Get-Changes-All privilege on the domain{' '}
+                {targetName}.
+            </p>
+            <p>
+                These two privileges allow a principal to perform a DCSync
+                attack.
+            </p>
+        </>
+    );
+};
+
+General.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
 };
 
 export default General;

--- a/src/components/Modals/HelpTexts/DCSync/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/Opsec.jsx
@@ -1,6 +1,12 @@
+import React from 'react';
+
 const Opsec = () => {
-    let text = `For detailed information on detection of dcsync as well as opsec considerations, see the adsecurity post in the references tab.`;
-    return { __html: text };
+    return (
+        <p>
+            For detailed information on detection of dcsync as well as opsec
+            considerations, see the adsecurity post in the references tab.
+        </p>
+    );
 };
 
 export default Opsec;

--- a/src/components/Modals/HelpTexts/DCSync/References.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/References.jsx
@@ -1,7 +1,17 @@
+import React from 'react';
+
 const References = () => {
-    let text = `<a href="https://adsecurity.org/?p=1729">https://adsecurity.org/?p=1729</a>
-            <a href="http://www.harmj0y.net/blog/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/">http://www.harmj0y.net/blog/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/</a>`;
-    return { __html: text };
+    return (
+        <>
+            <a href='https://adsecurity.org/?p=1729'>
+                https://adsecurity.org/?p=1729
+            </a>
+            <br />
+            <a href='http://www.harmj0y.net/blog/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/'>
+                http://www.harmj0y.net/blog/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/
+            </a>
+        </>
+    );
 };
 
 export default References;


### PR DESCRIPTION
Even though this is not a security issue I converted the remaining help texts to JSX components (like in #560) to improve code quality and consistency.