### PR TITLE
Added the SyncLAPSPassword edge with its documentation

### DIFF
--- a/docs/data-analysis/edges.rst
+++ b/docs/data-analysis/edges.rst
@@ -1937,6 +1937,42 @@ http://www.harmj0y.net/blog/redteaming/the-trustpocalypse/
 
 |
 
+SyncLAPSPassword
+^^^^^^^^^^^^^^^^^^^^
+
+A principal with this signifies the capability of retrieving, through a directory 
+synchronization, the value of confidential and RODC filtered attributes, such as 
+LAPS' *ms-Mcs-AdmPwd*.
+
+Abuse Info
+----------
+
+To abuse these privileges, use DirSync:
+    
+::
+
+    Sync-LAPS -LDAPFilter '(samaccountname=TargetComputer$)'
+    
+For other optional parameters, view the DirSync documentation.
+
+Opsec Considerations
+--------------------
+
+Executing the attack will generate a 4662 (An operation was performed on an object) 
+event at the domain controller if an appropriate SACL is in place on the target object.
+
+References
+----------
+
+* https://github.com/simondotsh/DirSync
+* https://simondotsh.com/infosec/2022/07/11/dirsync.html
+
+|
+
+----
+
+|
+
 AZAddMembers
 ^^^^^^^^^^^^
 

--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -69,7 +69,8 @@ const fullEdgeList = [
     'AdminTo',
     'AddSelf',
     'WriteSPN',
-    'AddKeyCredentialLink'
+    'AddKeyCredentialLink',
+    'SyncLAPSPassword'
 ];
 
 export default class AppContainer extends Component {

--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -399,6 +399,16 @@ const MenuContainer = () => {
             console.log(err);
         });
 
+        const createSyncLAPSPasswordStatement = "MATCH (n)-[:GetChangesInFilteredSet]->(m:Domain) WHERE (n)-[:GetChanges]->(m) AND NOT (n)-[:GetChangesAll]->(m) AND NOT n.objectid ENDS WITH '-S-1-5-9' MATCH (o:Computer {haslaps: true, domainsid: m.domainsid}) CREATE (n)-[:SyncLAPSPassword {isacl: true, isinherited: false}]->(o)"
+        await session.run(createSyncLAPSPasswordStatement, null).catch((err) => {
+            console.log(err);
+        });
+
+        const deleteGetChangesInFilteredSetStatement = "MATCH ()-[r:GetChangesInFilteredSet]->(:Domain) DELETE r"
+        await session.run(deleteGetChangesInFilteredSetStatement, null).catch((err) => {
+            console.log(err);
+        });
+
         await session.close();
         console.log("Post processing done")
     }

--- a/src/components/Modals/AddEdgeModal.jsx
+++ b/src/components/Modals/AddEdgeModal.jsx
@@ -149,7 +149,8 @@ const AddEdgeModal = () => {
             edgeValue === 'ReadLAPSPassword' ||
             edgeValue === 'WriteSPN' ||
             edgeValue === 'AddKeyCredentialLink' ||
-            edgeValue === 'AddSelf'
+            edgeValue === 'AddSelf' ||
+            edgeValue === 'SyncLAPSPassword'
         ) {
             edgepart = `[r:${edgeValue} {isacl: true}]`;
         } else if (edgeValue === 'SQLAdmin') {
@@ -311,6 +312,7 @@ const AddEdgeModal = () => {
                             </option>
                             <option value='SQLAdmin'>SQLAdmin</option>
                             <option value='HasSIDHistory'>HasSIDHistory</option>
+                            <option value='SyncLAPSPassword'>SyncLAPSPassword</option>
                         </FormControl>
                         {errors.edgeErrors.length > 0 && (
                             <span className={styles.error}>

--- a/src/components/Modals/HelpModal.jsx
+++ b/src/components/Modals/HelpModal.jsx
@@ -47,6 +47,7 @@ import Default from './HelpTexts/Default/Default';
 import WriteSPN from "./HelpTexts/WriteSPN/WriteSPN";
 import AddSelf from "./HelpTexts/AddSelf/AddSelf";
 import AddKeyCredentialLink from "./HelpTexts/AddKeyCredentialLink/AddKeyCredentialLink";
+import SyncLAPSPassword from "./HelpTexts/SyncLAPSPassword/SyncLAPSPassword";
 
 const HelpModal = () => {
     const [sourceName, setSourceName] = useState('');
@@ -124,7 +125,8 @@ const HelpModal = () => {
         AZVMContributor: AZVMContributor,
         WriteSPN: WriteSPN,
         AddSelf: AddSelf,
-        AddKeyCredentialLink: AddKeyCredentialLink
+        AddKeyCredentialLink: AddKeyCredentialLink,
+        SyncLAPSPassword: SyncLAPSPassword
     };
 
     const Component = edge in components ? components[edge] : Default;

--- a/src/components/Modals/HelpTexts/SyncLAPSPassword/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/SyncLAPSPassword/Abuse.jsx
@@ -1,0 +1,15 @@
+const Abuse = (sourceName, sourceType, targetName, targetType) => {
+    let text = `To abuse this privilege with DirSync, first import DirSync into your agent session or into a PowerShell instance at the console. You must authenticate to the Domain Controller as ${
+        sourceType === 'User'
+            ? `${sourceName} if you are not running a process as that user`
+            : `a member of ${sourceName} if you are not running a process as a member`
+    }. Then, execute the <code>Sync-LAPS</code> function:
+
+    <code>Sync-LAPS -LDAPFilter '(samaccountname=TargetComputer$)</code>
+
+    You can target a specific domain controller using the <code>-Server</code> parameter.
+    `;
+    return { __html: text };
+};
+
+export default Abuse;

--- a/src/components/Modals/HelpTexts/SyncLAPSPassword/General.jsx
+++ b/src/components/Modals/HelpTexts/SyncLAPSPassword/General.jsx
@@ -1,0 +1,13 @@
+import { groupSpecialFormat} from '../Formatter';
+
+const General = (sourceName, sourceType, targetName, targetType) => {
+    let text = `${groupSpecialFormat(
+        sourceType,
+        sourceName
+    )} the ability to synchronize the password set by Local Administrator Password Solution (LAPS) on the computer ${targetName}. 
+    
+    The local administrator password for a computer managed by LAPS is stored in the confidential and Read-Only Domain Controller (RODC) filtered LDAP attribute <code>ms-mcs-AdmPwd</code>.`;
+    return { __html: text };
+};
+
+export default General;

--- a/src/components/Modals/HelpTexts/SyncLAPSPassword/Opsec.jsx
+++ b/src/components/Modals/HelpTexts/SyncLAPSPassword/Opsec.jsx
@@ -1,0 +1,6 @@
+const Opsec = () => {
+    let text = `Executing the attack will generate a 4662 (An operation was performed on an object) event at the domain controller if an appropriate SACL is in place on the target object.`;
+    return { __html: text };
+};
+
+export default Opsec;

--- a/src/components/Modals/HelpTexts/SyncLAPSPassword/References.jsx
+++ b/src/components/Modals/HelpTexts/SyncLAPSPassword/References.jsx
@@ -1,0 +1,7 @@
+const References = () => {
+    let text = `<a href="https://github.com/simondotsh/DirSync">https://github.com/simondotsh/DirSync</a>
+            <a href="https://simondotsh.com/infosec/2022/07/11/dirsync.html">https://simondotsh.com/infosec/2022/07/11/dirsync.html</a>`;
+    return { __html: text };
+};
+
+export default References;

--- a/src/components/Modals/HelpTexts/SyncLAPSPassword/SyncLAPSPassword.jsx
+++ b/src/components/Modals/HelpTexts/SyncLAPSPassword/SyncLAPSPassword.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Tabs, Tab } from 'react-bootstrap';
+import General from './General';
+import Abuse from './Abuse';
+import Opsec from './Opsec';
+import References from './References';
+
+const SyncLAPSPassword = ({
+    sourceName,
+    sourceType,
+    targetName,
+    targetType,
+}) => {
+    return (
+        <Tabs defaultActiveKey={1} id='help-tab-container' justified>
+            <Tab
+                eventKey={1}
+                title='Info'
+                dangerouslySetInnerHTML={General(
+                    sourceName,
+                    sourceType,
+                    targetName,
+                    targetType
+                )}
+            />
+            <Tab
+                eventKey={2}
+                title='Abuse Info'
+                dangerouslySetInnerHTML={Abuse(
+                    sourceName,
+                    sourceType,
+                    targetName,
+                    targetType
+                )}
+            />
+            <Tab
+                eventKey={3}
+                title='Opsec Considerations'
+                dangerouslySetInnerHTML={Opsec()}
+            />
+            <Tab
+                eventKey={4}
+                title='References'
+                dangerouslySetInnerHTML={References()}
+            />
+        </Tabs>
+    );
+};
+
+SyncLAPSPassword.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
+    targetType: PropTypes.string,
+};
+export default SyncLAPSPassword;

--- a/src/components/SearchContainer/EdgeFilter/EdgeFilter.jsx
+++ b/src/components/SearchContainer/EdgeFilter/EdgeFilter.jsx
@@ -58,7 +58,8 @@ const EdgeFilter = ({ open }) => {
                             'ReadGMSAPassword',
                             'AddKeyCredentialLink',
                             'WriteSPN',
-                            'AddSelf'
+                            'AddSelf',
+                            'SyncLAPSPassword'
                         ]}
                         sectionName='ACL'
                     />
@@ -75,6 +76,7 @@ const EdgeFilter = ({ open }) => {
                     <EdgeFilterCheck name='AddKeyCredentialLink' />
                     <EdgeFilterCheck name='WriteSPN' />
                     <EdgeFilterCheck name='AddSelf' />
+                    <EdgeFilterCheck name='SyncLAPSPassword' />
                     <EdgeFilterSection
                         title='Containers'
                         sectionName='container'

--- a/src/index.js
+++ b/src/index.js
@@ -251,7 +251,8 @@ global.appStore = {
             CanPSRemote: 'tapered',
             AddSelf: 'tapered',
             WriteSPN: 'tapered',
-            AddKeyCredentialLink: 'tapered'
+            AddKeyCredentialLink: 'tapered',
+            SyncLAPSPassword: 'tapered',
         },
     },
     lowResPalette: {
@@ -292,6 +293,7 @@ global.appStore = {
             ReadGMSAPassword: 'line',
             HasSIDHistory: 'line',
             CanPSRemote: 'line',
+            SyncLAPSPassword: 'line'
         },
     },
     highResStyle: {
@@ -389,6 +391,7 @@ if (typeof conf.get('edgeincluded') === 'undefined') {
         ReadGMSAPassword: true,
         HasSIDHistory: true,
         CanPSRemote: true,
+        SyncLAPSPassword: true,
     });
 }
 


### PR DESCRIPTION
https://github.com/BloodHoundAD/BloodHound/issues/555

This edge requires to diverge from the typical way edges are built, due to how when a principal has `DS-Replication-Get-Changes` and `DS-Replication-Get-Changes-In-Filtered-Set` on a domain object, we wish to add a relationship between that principal and LAPS-enabled computers of the same domain. The ACE `DS-Replication-Get-Changes-In-Filtered-Set` is not currently collected, but a pull request has been opened on the SharpHoundCommon library to retrieve it (https://github.com/BloodHoundAD/SharpHoundCommon/pull/35).

Without restructuring the project, the easiest way that I could find to implement it was through executing Cypher queries after an import in the `postProcessUpload` function, since the edge involves different types of objects. Here are the creation queries:
```
MATCH (n)-[:GetChangesInFilteredSet]->(m:Domain) WHERE (n)-[:GetChanges]->(m) AND NOT (n)-[:GetChangesAll]->(m) AND NOT n.objectid ENDS WITH '-S-1-5-9' 
MATCH (o:Computer {haslaps: true, domainsid: m.domainsid}) 
CREATE (n)-[:SyncLAPSPassword {isacl: true, isinherited: false}]->(o)
```

We gather all objects `n` that have `GetChangesInFilteredSet` on the domain object. Then, we make sure that these `n` objects also have `GetChanges`, but not `GetChangesAll` on the domain. The latter is excluded because if a principal also has it, they can perform `DCSync`, and drawing `SyncLAPSPassword` in that case would only generate noise in the graph, in my opinion. Similarly, we make sure that `n` is not `Enterprise Domain Controllers` because it meets the previous requirements, but domain controllers are also members of the group `Domain Controllers`, awarding them `GetChangesAll`. As such, this would also induce noise.

Then, we filter on all computer objects of the same domain that have LAPS, and end with creating the relation `SyncLAPSPassword` between `n` and those computers. I set `isacl` to `true` because the edge is a combination of two ACEs, but feel free to adjust.

A last query is executed:

```
MATCH ()-[r:GetChangesInFilteredSet]->(:Domain) DELETE r
```

`GetChangesInFilteredSet` is not meant to be shown to users when they are querying the data. Currently, its only purpose is to build the `SyncLAPSPassword` edge; otherwise, it would be shown as a link to domain objects, and induce false positives. For this reason, we make sure to delete it.

While this is far from perfect, I believe it should be good enough as a first iteration. Do not hesitate to provide feedback, and do as you wish with this code.