### PR TITLE
nmp install

### DIFF
--- a/docs/installation/osx.rst
+++ b/docs/installation/osx.rst
@@ -40,7 +40,7 @@ Alternative: Build the BloodHound GUI
 
 ::
 
-   $ npm install -g electron-packager
+   $ npm install --location=global electron-packager
 
 3. Clone the BloodHound GitHub repo:
 


### PR DESCRIPTION
-g is not supported anymore and was replaced by --location=global as per the install notes

```
npm install -g electron-packager --global
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
```