### PR TITLE
Install latest instead of 4.0 Neo4j for Linux

### DIFF
--- a/docs/installation/linux.rst
+++ b/docs/installation/linux.rst
@@ -27,7 +27,7 @@ Install neo4j
 ::
 
   wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-  echo 'deb https://debian.neo4j.com stable 4.0' > /etc/apt/sources.list.d/neo4j.list
+  echo 'deb https://debian.neo4j.com stable latest' > /etc/apt/sources.list.d/neo4j.list
   sudo apt-get update
 
 2. Install apt-transport-https with apt


### PR DESCRIPTION
According to a BloodHoundGang slack user, BH requires 4.4+ Neo4j. I guess it makes sense to pull the latest version.