### PR TITLE
Support for AZ automation account, function apps, logic apps(workflows) and storage accounts

### DIFF
--- a/src/components/SearchContainer/TabContainer.jsx
+++ b/src/components/SearchContainer/TabContainer.jsx
@@ -27,6 +27,9 @@ import BaseNodeData from "./Tabs/BaseNodeData";
 import ContainerNodeData from "./Tabs/ContainerNodeData";
 import AZManagementGroupNodeData from "./Tabs/AZManagementGroupNodeData";
 import AZRoleNodeData from "./Tabs/AZRoleNodeData";
+import AZStorageAccountNodeData from './Tabs/AZStorageAccountNodeData';
+import AZStorageContainerNodeData from './Tabs/AZStorageContainerNodeData';
+import AZLogicAppNodeData from './Tabs/AZLogicAppNodeData';
 
 class TabContainer extends Component {
 
@@ -50,6 +53,9 @@ class TabContainer extends Component {
             azSubscriptionVisible: false,
             azTenantVisible: false,
             azVMVisible: false,
+            azStorageAccountVisible: false,
+            azStorageContainerVisible: false,
+            azLogicAppVisible: false,
             azServicePrincipalVisible: false,
             azAppVisible: false,
             azManagementGroupVisible: false,
@@ -109,6 +115,12 @@ class TabContainer extends Component {
             this._azManagementGroupNodeClicked()
         } else if (type === 'AZRole') {
             this._azRoleNodeClicked()
+        } else if (type === 'AZStorageAccount') {
+            this._azStorageAccountNodeClicked();
+        } else if (type === 'AZStorageContainer'){
+            this._azStorageContainerNodeClicked();
+        } else if (type === 'AZLogicApp'){
+            this._azLogicAppNodeClicked();
         }
     }
 
@@ -278,6 +290,30 @@ class TabContainer extends Component {
         });
     }
 
+    _azStorageAccountNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azStorageAccountVisble: true,
+            selected: 2
+        });
+    }
+
+    _azStorageContainerNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azStorageContainerVisble: true,
+            selected: 2
+        });
+    }
+
+    _azLogicAppNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azLogicAppVisible: true,
+            selected: 2
+        });
+    }
+
     _azServicePrincipalNodeClicked() {
         this.clearVisible()
         this.setState({
@@ -330,6 +366,9 @@ class TabContainer extends Component {
                                 !this.state.azSubscriptionVisible &&
                                 !this.state.azTenantVisible &&
                                 !this.state.azVMVisible &&
+                                !this.state.azStorageAccountVisble &&
+                                !this.state.azStorageContainerVisible &&
+                                !this.state.azLogicAppVisible &&
                                 !this.state.azServicePrincipalVisible &&
                                 !this.state.azAppVisible &&
                                 !this.state.baseVisible &&
@@ -365,6 +404,9 @@ class TabContainer extends Component {
                             visible={this.state.azTenantVisible}
                         />
                         <AZVMNodeData visible={this.state.azVMVisible} />
+                        <AZStorageAccountNodeData visible={this.state.azStorageAccountVisble} />
+                        <AZStorageContainerNodeData visible={this.state.azStorageContainerVisible} />
+                        <AZLogicAppNodeData visible={this.state.azLogicAppVisible} />
                         <AZServicePrincipalNodeData
                             visible={this.state.azServicePrincipalVisible}
                         />

--- a/src/components/SearchContainer/TabContainer.jsx
+++ b/src/components/SearchContainer/TabContainer.jsx
@@ -30,6 +30,8 @@ import AZRoleNodeData from "./Tabs/AZRoleNodeData";
 import AZStorageAccountNodeData from './Tabs/AZStorageAccountNodeData';
 import AZStorageContainerNodeData from './Tabs/AZStorageContainerNodeData';
 import AZLogicAppNodeData from './Tabs/AZLogicAppNodeData';
+import AZFunctionAppNodeData from './Tabs/AZFunctionAppNodeData';
+import AZAutomationAccountNodeData from './Tabs/AZAutomationAccountNodeData';
 
 class TabContainer extends Component {
 
@@ -56,6 +58,8 @@ class TabContainer extends Component {
             azStorageAccountVisible: false,
             azStorageContainerVisible: false,
             azLogicAppVisible: false,
+            azFunctionAppVisible: false,
+            azAutomationAccountVisible: false,
             azServicePrincipalVisible: false,
             azAppVisible: false,
             azManagementGroupVisible: false,
@@ -121,6 +125,10 @@ class TabContainer extends Component {
             this._azStorageContainerNodeClicked();
         } else if (type === 'AZLogicApp'){
             this._azLogicAppNodeClicked();
+        } else if (type === 'AZFunctionApp') {
+            this._azFunctionAppNodeClicked();
+        } else if (type === 'AZAutomationAccount') {
+            this._azAutomationAccountNodeClicked();
         }
     }
 
@@ -314,6 +322,22 @@ class TabContainer extends Component {
         });
     }
 
+    _azFunctionAppNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azFunctionAppVisible: true,
+            selected: 2
+        });   
+    }
+
+    _azAutomationAccountNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azAutomationAccountVisible: true,
+            selected: 2
+        });
+    }
+
     _azServicePrincipalNodeClicked() {
         this.clearVisible()
         this.setState({
@@ -369,6 +393,8 @@ class TabContainer extends Component {
                                 !this.state.azStorageAccountVisble &&
                                 !this.state.azStorageContainerVisible &&
                                 !this.state.azLogicAppVisible &&
+                                !this.state.azFunctionAppVisible &&
+                                !this.state.azAutomationAccountVisible &&
                                 !this.state.azServicePrincipalVisible &&
                                 !this.state.azAppVisible &&
                                 !this.state.baseVisible &&
@@ -407,6 +433,8 @@ class TabContainer extends Component {
                         <AZStorageAccountNodeData visible={this.state.azStorageAccountVisble} />
                         <AZStorageContainerNodeData visible={this.state.azStorageContainerVisible} />
                         <AZLogicAppNodeData visible={this.state.azLogicAppVisible} />
+                        <AZFunctionAppNodeData visble={this.state.azFunctionAppVisible} />
+                        <AZAutomationAccountNodeData visible={this.state.azAutomationAccountVisible} />
                         <AZServicePrincipalNodeData
                             visible={this.state.azServicePrincipalVisible}
                         />

--- a/src/components/SearchContainer/Tabs/AZAutomationAccountNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZAutomationAccountNodeData.jsx
@@ -1,0 +1,164 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZAutomationAccountNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZAutomationAccount') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZAutomationAccount {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Automation Account within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Automation Account within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZAutomationAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZAutomationAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Automation Account Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Automation Account Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Automation Account User Access Administrators'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZAutomationAccountNodeData.propTypes = {};
+export default AZAutomationAccountNodeData;

--- a/src/components/SearchContainer/Tabs/AZFunctionAppNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZFunctionAppNodeData.jsx
@@ -1,0 +1,164 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZFunctionAppNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZFunctionApp') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZFunctionApp {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Function App within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Function App within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZFunctionApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZFunctionApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Function App Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Function App Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZFunctionApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Function App User Access Administrators'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZFunctionAppNodeData.propTypes = {};
+export default AZFunctionAppNodeData;

--- a/src/components/SearchContainer/Tabs/AZLogicAppNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZLogicAppNodeData.jsx
@@ -1,0 +1,164 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZLogicAppNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZLogicApp') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZLogicApp {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Logic app(Workflow) within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Logic App within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZLogicApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZLogicApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Logic App(Workflow) Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Logic App(Workflow) Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Logic App(Workflow) User Access Administrators'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZLogicAppNodeData.propTypes = {};
+export default AZLogicAppNodeData;

--- a/src/components/SearchContainer/Tabs/AZStorageAccountNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZStorageAccountNodeData.jsx
@@ -1,0 +1,194 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZStorageAccountNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZStorageAccount') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZStorageAccount {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Storage Account within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Storage Account within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZStorageAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZStorageAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (u:AZStorageAccount {objectid: $objectid})-[r:AZContains*1..]->(d) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (u:AZStorageAccount {objectid: $objectid})-[r:AZContains*1..]->(d) RETURN p'
+                                    }
+                                    property={'Storage Containers'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZSADataReader*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZSADataReader*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Data Readers'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZSAKeyOperator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZSAKeyOperator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Key Operators'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account User Access Administrators'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZStorageAccountNodeData.propTypes = {};
+export default AZStorageAccountNodeData;

--- a/src/components/SearchContainer/Tabs/AZStorageContainerNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZStorageContainerNodeData.jsx
@@ -1,0 +1,177 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZStorageContainerNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZStorageContainer') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZStorageContainer {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Storage Container within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='Resource group / Storage Account'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='Storage Account'
+                                    query='MATCH p = (d:AZStorageAccount)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZOwns*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZContributor*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZSADataReader*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZSADataReader*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Data Readers'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZSAKeyOperator*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZSAKeyOperator*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Key Operators'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:AZUserAccessAdministrator*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container User Access Administrators'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZStorageContainerNodeData.propTypes = {};
+export default AZStorageContainerNodeData;

--- a/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
@@ -206,6 +206,26 @@ const DatabaseDataDisplay = () => {
                             index={index}
                             label={'AZVM'}
                         />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZStorageAccount) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZStorageAccount'}
+                        />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZAutomationAccount) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZAutomationAccount'}
+                        />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZLogicApp) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZLogicApp(Workflow)'}
+                        />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZFunctionApp) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZFunctionApp'}
+                        />
                     </tbody>
                 </Table>
             </CollapsibleSection>

--- a/src/js/newingestion.js
+++ b/src/js/newingestion.js
@@ -83,7 +83,8 @@ export const AzureLabels = {
     StorageAccountDataReader: 'AZSADataReader',
     StorageAccountKeyOperator: 'AZSAKeyOperator',
     AutomationAccount: 'AZAutomationAccount',
-    LogicApp: 'AZLogicApp'
+    LogicApp: 'AZLogicApp',
+    FunctionApp: 'AZFunctionApp'
 };
 
 const AzurehoundKindLabels = {
@@ -136,7 +137,11 @@ const AzurehoundKindLabels = {
     KindAZLogicApp: 'AZWorkflow',
     KindAZLogicAppOwner: 'AZWorkflowOwner',
     KindAZLogicAppContributor: 'AZWorkflowContributor',
-    KindAZLogicAppUserAccessAdmin: 'AZWorkflowUserAccessAdmin'
+    KindAZLogicAppUserAccessAdmin: 'AZWorkflowUserAccessAdmin',
+    KindAZFunctionApp: 'AZFunctionApp',
+    KindAZFunctionAppOwner: 'AZFunctionAppOwner',
+    KindAZFunctionAppContributor: 'AZFunctionAppContributor',
+    KindAZFunctionAppUserAccessAdmin: 'AZFunctionAppUserAccessAdmin',
 
 };
 
@@ -1093,7 +1098,7 @@ export function convertAzureData(chunk) {
                 convertAzureStorageAccountKeyOperators(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZSAUserAccessAdmin:
-                convertAzureStorageAccountUserAccessAdmin(item.data, data);
+                convertAzureStorageAccountUserAccessAdmins(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZStorageContainer:
                 convertAzureStorageContainer(item.data, data);
@@ -1102,25 +1107,37 @@ export function convertAzureData(chunk) {
                 convertAzureAutomationAccount(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZAAOwner:
-                convertAzureAutomationAccountOwner(item.data, data);
+                convertAzureAutomationAccountOwners(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZAAContributor:
-                convertAzureAutomationAccountContributor(item.data,data);
+                convertAzureAutomationAccountContributors(item.data,data);
                 break;
             case AzurehoundKindLabels.KindAZAAUserAccessAdmin:
-                convertAzureAutomationAccountUserAccessAdmin(item.data, data);
+                convertAzureAutomationAccountUserAccessAdmins(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZLogicApp:
                 convertAzureLogicApp(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZLogicAppOwner:
-                convertAzureLogicAppOwner(item.data, data);
+                convertAzureLogicAppOwners(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZLogicAppContributor:
-                convertAzureLogicAppContributor(item.data, data);
+                convertAzureLogicAppContributors(item.data, data);
                 break;
             case AzurehoundKindLabels.KindAZLogicAppUserAccessAdmin:
-                convertAzureLogicAppUserAccessAdmin(item.data, data);
+                convertAzureLogicAppUserAccessAdmins(item.data, data);
+                break;
+            case AzurehoundKindLabels.KindAZFunctionApp:
+                convertAzureFunctionApp(item.data, data);
+                break;
+            case AzurehoundKindLabels.KindAZFunctionAppOwner:
+                convertAzureFunctionAppOwners(item.data, data);
+                break;
+            case AzurehoundKindLabels.KindAZFunctionAppContributor:
+                convertAzureFunctionAppContributors(item.data, data);
+                break;
+            case AzurehoundKindLabels.KindAZFunctionAppUserAccessAdmin:
+                convertAzureFunctionAppUserAccessAdmins(item.data, data);
                 break;
             default:
                 console.error(`invalid azure type detected: ${item.kind}`);
@@ -2239,8 +2256,6 @@ export function convertAzureVirtualMachineUserAccessAdmins(
     );
 }
 
-
-
 /**
  *
  * @param {AzureStorageAccountContributors} data
@@ -2338,7 +2353,7 @@ export function convertAzureStorageAccountKeyOperators(data, ingestionData){
  * @param {AzureStorageAccountUserAccessAdmins} data
  * @param ingestionData
  */
-export function convertAzureStorageAccountUserAccessAdmin(data, ingestionData){
+export function convertAzureStorageAccountUserAccessAdmins(data, ingestionData){
     if (data.userAccessAdmins === null) return;
     for (let userAccessAdmin of data.userAccessAdmins) {
         insertNewAzureRel(
@@ -2494,14 +2509,13 @@ export function convertAzureStorageContainer(
         }
     }
 }
-
-           
+         
 /**
  *
  * @param {AzureAutomationAccountOwners} data
  * @param ingestionData
  */
-export function convertAzureAutomationAccountOwner(data, ingestionData) {
+export function convertAzureAutomationAccountOwners(data, ingestionData) {
     if (data.owners === null) return;
     for (let owner of data.owners) {
         insertNewAzureRel(
@@ -2524,7 +2538,7 @@ export function convertAzureAutomationAccountOwner(data, ingestionData) {
  * @param {AzureAutomationAccountContributors} data
  * @param ingestionData
  */
- export function convertAzureAutomationAccountContributor(data, ingestionData) {
+ export function convertAzureAutomationAccountContributors(data, ingestionData) {
     if (data.contributors === null) return;
     for (let contributor of data.contributors) {
         insertNewAzureRel(
@@ -2547,7 +2561,7 @@ export function convertAzureAutomationAccountOwner(data, ingestionData) {
  * @param {AzureAutomationAccountUserAccessAdmin} data
  * @param ingestionData
  */
- export function convertAzureAutomationAccountUserAccessAdmin(data, ingestionData) {
+ export function convertAzureAutomationAccountUserAccessAdmins(data, ingestionData) {
     if (data.userAccessAdmins === null) return;
     for (let userAccessAdmin of data.userAccessAdmins) {
         insertNewAzureRel(
@@ -2648,7 +2662,7 @@ export function convertAzureAutomationAccountOwner(data, ingestionData) {
  * @param {AzureLogicAppOwners} data
  * @param ingestionData
  */
-export function convertAzureLogicAppOwner(data, ingestionData) {
+export function convertAzureLogicAppOwners(data, ingestionData) {
     if (data.owners === null) return;
     for (let owner of data.owners) {
         insertNewAzureRel(
@@ -2671,7 +2685,7 @@ export function convertAzureLogicAppOwner(data, ingestionData) {
  * @param {AzureLogicAppContributors} data
  * @param ingestionData
  */
- export function convertAzureLogicAppContributor(data, ingestionData) {
+ export function convertAzureLogicAppContributors(data, ingestionData) {
     if (data.contributors === null) return;
     for (let contributor of data.contributors) {
         insertNewAzureRel(
@@ -2694,7 +2708,7 @@ export function convertAzureLogicAppOwner(data, ingestionData) {
  * @param {AzureLogicAppUserAccessAdmins} data
  * @param ingestionData
  */
- export function convertAzureLogicAppUserAccessAdmin(data, ingestionData) {
+ export function convertAzureLogicAppUserAccessAdmins(data, ingestionData) {
     if (data.userAccessAdmins === null) return;
     for (let userAccessAdmin of data.userAccessAdmins) {
         insertNewAzureRel(
@@ -2711,6 +2725,153 @@ export function convertAzureLogicAppOwner(data, ingestionData) {
         );
     }
 }
+
+/**
+ *
+ * @param {AzureFunctionApp} data
+ * @param ingestionData
+ */
+export function convertAzureFunctionApp(data, ingestionData) {
+    insertNewAzureNodeProp(
+        ingestionData,
+        AzureLabels.FunctionApp,
+        {
+            objectid: data.id.toUpperCase(),
+            map: {
+                name: data.name.toUpperCase(),
+                tenantid: data.tenantId.toUpperCase()
+            },
+        },
+        false
+    );
+
+    insertNewAzureRel(
+        ingestionData,
+        fProps(AzureLabels.Tenant, AzureLabels.FunctionApp, AzureLabels.Contains),
+        {
+            source: data.tenantId.toUpperCase(),
+            target: data.id.toUpperCase(),
+        }
+    );
+
+    insertNewAzureRel(
+        ingestionData,
+        fProps(
+            AzureLabels.ResourceGroup,
+            AzureLabels.FunctionApp,
+            AzureLabels.Contains
+        ),
+        {
+            source: data.resourceGroupId.toUpperCase(),
+            target: data.id.toUpperCase(),
+        }
+    );
+
+    if (data.identity.principalId) {
+        insertNewAzureRel(
+            ingestionData,
+            fProps(
+                AzureLabels.FunctionApp,
+                AzureLabels.ServicePrincipal,
+                AzureLabels.ManagedIdentity
+            ),
+            {
+                source: data.id.toUpperCase(),
+                target: data.identity.principalId.toUpperCase(),
+            }
+        );
+    }
+
+    if (data.identity.userAssignedIdentities) {
+        for (let key in data.identity.userAssignedIdentities) {
+            let user = data.identity.userAssignedIdentities[key];
+            if (user.clientId !== '') {
+                insertNewAzureRel(
+                    ingestionData,
+                    fProps(
+                        AzureLabels.FunctionApp,
+                        AzureLabels.ServicePrincipal,
+                        AzureLabels.ManagedIdentity
+                    ),
+                    {
+                        source: data.id.toUpperCase(),
+                        target: user.principalId.toUpperCase(),
+                    }
+                );
+            }
+        }
+    }
+}
+
+/**
+ *
+ * @param {AzureFunctionAppOwners} data
+ * @param ingestionData
+ */
+ export function convertAzureFunctionAppOwners(data, ingestionData) {
+    if (data.owners === null) return;
+    for (let owner of data.owners) {
+        insertNewAzureRel(
+            ingestionData,
+            fProps(
+                AzureLabels.Base,
+                AzureLabels.FunctionApp,
+                AzureLabels.Owns
+            ),
+            {
+                source: owner.owner.properties.principalId.toUpperCase(),
+                target: owner.owner.properties.scope.toUpperCase(),
+            }
+        );
+    }
+}
+                
+/**
+ *
+ * @param {AzureFunctionAppContributors} data
+ * @param ingestionData
+ */
+ export function convertAzureFunctionAppContributors(data, ingestionData) {
+    if (data.contributors === null) return;
+    for (let contributor of data.contributors) {
+        insertNewAzureRel(
+            ingestionData,
+            fProps(
+                AzureLabels.Base,
+                AzureLabels.FunctionApp,
+                AzureLabels.Contributor
+            ),
+            {
+                source: contributor.contributor.properties.principalId.toUpperCase(),
+                target: contributor.contributor.properties.scope.toUpperCase(),
+            }
+        );
+    }
+}
+
+/**
+ *
+ * @param {AzureFunctionAppUserAccessAdmins} data
+ * @param ingestionData
+ */
+ export function convertAzureFunctionAppUserAccessAdmins(data, ingestionData) {
+    if (data.userAccessAdmins === null) return;
+    for (let userAccessAdmin of data.userAccessAdmins) {
+        insertNewAzureRel(
+            ingestionData,
+            fProps(
+                AzureLabels.Base,
+                AzureLabels.FunctionApp,
+                AzureLabels.UserAccessAdministrator
+            ),
+            {
+                source: userAccessAdmin.userAccessAdmin.properties.principalId.toUpperCase(),
+                target: userAccessAdmin.userAccessAdmin.properties.scope.toUpperCase(),
+            }
+        );
+    }
+}
+
 
 
 /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -213,8 +213,8 @@ async function dropIndexes() {
 
 export async function setSchema() {
     const luceneIndexProvider = "lucene+native-3.0"
-    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer"]
-    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer"]
+    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount"]
+    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount"]
     let schema = {}
     for (let label of labels){
         schema[label] = {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -213,8 +213,8 @@ async function dropIndexes() {
 
 export async function setSchema() {
     const luceneIndexProvider = "lucene+native-3.0"
-    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount"]
-    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount"]
+    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount", "AZLogicApp"]
+    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount", "AZLogicApp"]
     let schema = {}
     for (let label of labels){
         schema[label] = {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -18,7 +18,8 @@ const labels = [
     'AZUser',
     'AZVM',
     'AZRole',
-    'AZManagementGroup'
+    'AZManagementGroup',
+    'AZStorageAccount'
 ];
 
 export function generateUniqueId(sigmaInstance, isNode) {
@@ -212,7 +213,7 @@ async function dropIndexes() {
 export async function setSchema() {
     const luceneIndexProvider = "lucene+native-3.0"
     let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM"]
-    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM"]
+    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount"]
     let schema = {}
     for (let label of labels){
         schema[label] = {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,6 +21,9 @@ const labels = [
     'AZManagementGroup',
     'AZStorageAccount',
     'AZStorageContainer',
+    'AZAutomationAccount',
+    'AZLogicApp',
+    'AZFunctionApp',
 ];
 
 export function generateUniqueId(sigmaInstance, isNode) {
@@ -213,8 +216,8 @@ async function dropIndexes() {
 
 export async function setSchema() {
     const luceneIndexProvider = "lucene+native-3.0"
-    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount", "AZLogicApp"]
-    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount", "AZLogicApp"]
+    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount", "AZLogicApp", "AZFunctionApp"]
+    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer", "AZAutomationAccount", "AZLogicApp", "AZFunctionApp"]
     let schema = {}
     for (let label of labels){
         schema[label] = {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -19,7 +19,8 @@ const labels = [
     'AZVM',
     'AZRole',
     'AZManagementGroup',
-    'AZStorageAccount'
+    'AZStorageAccount',
+    'AZStorageContainer',
 ];
 
 export function generateUniqueId(sigmaInstance, isNode) {
@@ -212,8 +213,8 @@ async function dropIndexes() {
 
 export async function setSchema() {
     const luceneIndexProvider = "lucene+native-3.0"
-    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM"]
-    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount"]
+    let labels = ["User", "Group", "Computer", "GPO", "OU", "Domain", "Container", "Base", "AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer"]
+    let azLabels = ["AZBase", "AZApp", "AZDevice", "AZGroup", "AZKeyVault", "AZResourceGroup", "AZServicePrincipal", "AZTenant", "AZUser", "AZVM", "AZStorageAccount", "AZStorageContainer"]
     let schema = {}
     for (let label of labels){
         schema[label] = {


### PR DESCRIPTION
The following new nodes have been added:
* Automation account
* Function app
* Logic app(workflow)
* Storage account
* Storage container

Besides the already existing Owner, Contributor and User Access Admin the following relationships have also been added:
* DataReader (for Storage Account)
* Key Account Operator (for Storage Account)

Database Info is also populated with the elements:
![image](https://user-images.githubusercontent.com/10261812/187931215-1b3aa876-4278-4aeb-9633-492b1870e157.png)


Node info for each of the nodes is also populated with their properties and some basic relationship info:
![image](https://user-images.githubusercontent.com/10261812/187931441-98b18505-5246-4de8-bd00-5d4f4a20c633.png)
![image](https://user-images.githubusercontent.com/10261812/187931736-d4f7cc73-abfd-42e1-8a93-bd9524c712ab.png)


The resources can also be queried via Azurehound, submitted in a [PR here](https://github.com/BloodHoundAD/AzureHound/pull/10)

Let me know if there are any improvement ideas.