### PR TITLE
Fix Wrong Statements In Azure Post Processing setGlobalAdminHighValue & setPrivRoleAdminHighValue

### DIFF
--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -585,8 +585,8 @@ const MenuContainer = () => {
             type: 'query',
             statement: `MATCH (n:AZRole {templateid:"E8611AB8-C189-46E8-94E1-60213AB1F814"})
                 OPTIONAL MATCH (g:AZGroup)-[:AZHasRole]->(n)
-                OPTIONAL MATCH (i)-[:AZMemberOf]->(g) WHERE n:AZUser OR n:AZServicePrincipal OR n:AZDevice
-                OPTIONAL MATCH (p)-[:AZHasRole]->(n) WHERE n:AZUser OR n:AZServicePrincipal OR n:AZDevice
+                OPTIONAL MATCH (i)-[:AZMemberOf]->(g) WHERE i:AZUser OR i:AZServicePrincipal OR i:AZDevice
+                OPTIONAL MATCH (p)-[:AZHasRole]->(n) WHERE p:AZUser OR p:AZServicePrincipal OR p:AZDevice
                 CALL {
                     WITH g,i,p
                     SET g.highvalue=true, i.highvalue=true, p.highvalue=true

--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -571,8 +571,8 @@ const MenuContainer = () => {
             type: 'query',
             statement: `MATCH (n:AZRole {templateid:"62E90394-69F5-4237-9190-012177145E10"})
                 OPTIONAL MATCH (g:AZGroup)-[:AZHasRole]->(n)
-                OPTIONAL MATCH (i)-[:AZMemberOf]->(g) WHERE n:AZUser OR n:AZServicePrincipal OR n:AZDevice
-                OPTIONAL MATCH (p)-[:AZHasRole]->(n) WHERE n:AZUser OR n:AZServicePrincipal OR n:AZDevice
+                OPTIONAL MATCH (i)-[:AZMemberOf]->(g) WHERE i:AZUser OR i:AZServicePrincipal OR i:AZDevice
+                OPTIONAL MATCH (p)-[:AZHasRole]->(n) WHERE p:AZUser OR p:AZServicePrincipal OR p:AZDevice
                 CALL {
                     WITH g,i,p
                     SET g.highvalue=true, i.highvalue=true, p.highvalue=true


### PR DESCRIPTION
Two cypher statements in Azure post processing are referencing the wrong variable (n) in their WHERE clause.

Due to this bug, no nodes of the types AZUser, AZServicePrincipal or AZDevice that have the corresponding roles, or are member of a role-assigned group are marked as highvalue.