### PR TITLE
Fix edgeIncluded label partially clickable

### DIFF
--- a/src/components/SearchContainer/EdgeFilter/EdgeFilterCheck.jsx
+++ b/src/components/SearchContainer/EdgeFilter/EdgeFilterCheck.jsx
@@ -11,13 +11,14 @@ const EdgeFilterCheck = ({ name }) => {
 
     return (
         <div className={styles.input}>
-            <input
-                className='checkbox-inline'
-                type='checkbox'
-                checked={context.edgeIncluded[name]}
-                onChange={handleChange}
-            />
-            <label onClick={handleChange}>{name}</label>
+            <label>
+                <input
+                    className='checkbox-inline'
+                    type='checkbox'
+                    checked={context.edgeIncluded[name]}
+                    onChange={handleChange}
+                />
+            {name}</label>
         </div>
     );
 };


### PR DESCRIPTION
Label is now also in the clickable zone and will return a boolean value for e.target.checked instead of undefined.
for more info: https://stackoverflow.com/questions/6293588/how-to-create-a-checkbox-with-a-clickable-label