### PR TITLE
Support for extra Azure resources + their role assignments

### DIFF
--- a/src/components/SearchContainer/TabContainer.jsx
+++ b/src/components/SearchContainer/TabContainer.jsx
@@ -30,6 +30,7 @@ import AZRoleNodeData from "./Tabs/AZRoleNodeData";
 import AZStorageAccountNodeData from './Tabs/AZStorageAccountNodeData';
 import AZStorageContainerNodeData from './Tabs/AZStorageContainerNodeData';
 import AZAutomationAccountNodeData from './Tabs/AZAutomationAccountNodeData';
+import AZLogicAppNodeData from './Tabs/AZLogicAppNodeData';
 
 class TabContainer extends Component {
 
@@ -57,6 +58,7 @@ class TabContainer extends Component {
             azStorageAccountVisible: false,
             azStorageContainerVisible: false,
             azAutomationAccountVisible: false,
+            azLogicAppVisible: false,
             azAppVisible: false,
             azManagementGroupVisible: false,
             azRoleVisible: false,
@@ -121,6 +123,8 @@ class TabContainer extends Component {
             this._azStorageContainerNodeClicked();
         } else if (type === 'AZAutomationAccount') {
             this._azAutomationAccountNodeClicked();
+        } else if (type === 'AZLogicApp') {
+            this._azLogicAppNodeClicked();
         }
 
     }
@@ -323,6 +327,14 @@ class TabContainer extends Component {
         });
     }
 
+    _azLogicAppNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azLogicAppVisible: true,
+            selected: 2
+        });
+    }
+
     _azAppNodeClicked() {
         this.clearVisible()
         this.setState({
@@ -371,6 +383,7 @@ class TabContainer extends Component {
                                 !this.state.azStorageAccountVisble &&
                                 !this.state.azStorageContainerVisble &&
                                 !this.state.azAutomationAccountVisible &&
+                                !this.state.azLogicAppVisible &&
                                 !this.state.azAppVisible &&
                                 !this.state.baseVisible &&
                                 !this.state.azManagementGroupVisible &&
@@ -411,6 +424,7 @@ class TabContainer extends Component {
                         <AZStorageAccountNodeData visible={this.state.azStorageAccountVisble} />
                         <AZStorageContainerNodeData visible={this.state.azStorageContainerVisible} />
                         <AZAutomationAccountNodeData visible={this.state.azAutomationAccountVisible} />
+                        <AZLogicAppNodeData visible={this.state.azLogicAppVisible} />
                         <AZAppNodeData visible={this.state.azAppVisible} />
                         <AZManagementGroupNodeData visible={this.state.azManagementGroupVisible} />
                         <AZRoleNodeData visible={this.state.azRoleVisible} />

--- a/src/components/SearchContainer/TabContainer.jsx
+++ b/src/components/SearchContainer/TabContainer.jsx
@@ -31,6 +31,7 @@ import AZStorageAccountNodeData from './Tabs/AZStorageAccountNodeData';
 import AZStorageContainerNodeData from './Tabs/AZStorageContainerNodeData';
 import AZAutomationAccountNodeData from './Tabs/AZAutomationAccountNodeData';
 import AZLogicAppNodeData from './Tabs/AZLogicAppNodeData';
+import AZWebAppNodeData from './Tabs/AZWebAppNodeData';
 
 class TabContainer extends Component {
 
@@ -59,6 +60,7 @@ class TabContainer extends Component {
             azStorageContainerVisible: false,
             azAutomationAccountVisible: false,
             azLogicAppVisible: false,
+            azWebAppVisible: false,
             azAppVisible: false,
             azManagementGroupVisible: false,
             azRoleVisible: false,
@@ -125,6 +127,8 @@ class TabContainer extends Component {
             this._azAutomationAccountNodeClicked();
         } else if (type === 'AZLogicApp') {
             this._azLogicAppNodeClicked();
+        } else if (type === 'AZWebApp') {
+            this._azWebAppNodeClicked();
         }
 
     }
@@ -335,6 +339,14 @@ class TabContainer extends Component {
         });
     }
 
+    _azWebAppNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azWebAppVisible: true,
+            selected: 2
+        });
+    }
+
     _azAppNodeClicked() {
         this.clearVisible()
         this.setState({
@@ -384,6 +396,7 @@ class TabContainer extends Component {
                                 !this.state.azStorageContainerVisble &&
                                 !this.state.azAutomationAccountVisible &&
                                 !this.state.azLogicAppVisible &&
+                                !this.state.azWebAppVisible &&
                                 !this.state.azAppVisible &&
                                 !this.state.baseVisible &&
                                 !this.state.azManagementGroupVisible &&
@@ -425,6 +438,7 @@ class TabContainer extends Component {
                         <AZStorageContainerNodeData visible={this.state.azStorageContainerVisible} />
                         <AZAutomationAccountNodeData visible={this.state.azAutomationAccountVisible} />
                         <AZLogicAppNodeData visible={this.state.azLogicAppVisible} />
+                        <AZWebAppNodeData visible={this.state.azWebAppVisible} />
                         <AZAppNodeData visible={this.state.azAppVisible} />
                         <AZManagementGroupNodeData visible={this.state.azManagementGroupVisible} />
                         <AZRoleNodeData visible={this.state.azRoleVisible} />

--- a/src/components/SearchContainer/TabContainer.jsx
+++ b/src/components/SearchContainer/TabContainer.jsx
@@ -27,6 +27,8 @@ import BaseNodeData from "./Tabs/BaseNodeData";
 import ContainerNodeData from "./Tabs/ContainerNodeData";
 import AZManagementGroupNodeData from "./Tabs/AZManagementGroupNodeData";
 import AZRoleNodeData from "./Tabs/AZRoleNodeData";
+import AZStorageAccountNodeData from './Tabs/AZStorageAccountNodeData';
+import AZStorageContainerNodeData from './Tabs/AZStorageContainerNodeData';
 
 class TabContainer extends Component {
 
@@ -51,6 +53,8 @@ class TabContainer extends Component {
             azTenantVisible: false,
             azVMVisible: false,
             azServicePrincipalVisible: false,
+            azStorageAccountVisible: false,
+            azStorageContainerVisible: false,
             azAppVisible: false,
             azManagementGroupVisible: false,
             azRoleVisible: false,
@@ -109,7 +113,12 @@ class TabContainer extends Component {
             this._azManagementGroupNodeClicked()
         } else if (type === 'AZRole') {
             this._azRoleNodeClicked()
+        } else if (type === 'AZStorageAccount') {
+            this._azStorageAccountNodeClicked();
+        } else if (type === 'AZStorageContainer') {
+            this._azStorageContainerNodeClicked();
         }
+
     }
 
     componentDidMount() {
@@ -286,6 +295,22 @@ class TabContainer extends Component {
         });
     }
 
+    _azStorageAccountNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azStorageAccountVisible: true,
+            selected: 2
+        });
+    }
+
+    _azStorageContainerNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azStorageContainerVisible: true,
+            selected: 2
+        });
+    }
+
     _azAppNodeClicked() {
         this.clearVisible()
         this.setState({
@@ -331,6 +356,8 @@ class TabContainer extends Component {
                                 !this.state.azTenantVisible &&
                                 !this.state.azVMVisible &&
                                 !this.state.azServicePrincipalVisible &&
+                                !this.state.azStorageAccountVisble &&
+                                !this.state.azStorageContainerVisble &&
                                 !this.state.azAppVisible &&
                                 !this.state.baseVisible &&
                                 !this.state.azManagementGroupVisible &&
@@ -368,6 +395,8 @@ class TabContainer extends Component {
                         <AZServicePrincipalNodeData
                             visible={this.state.azServicePrincipalVisible}
                         />
+                        <AZStorageAccountNodeData visible={this.state.azStorageAccountVisble} />
+                        <AZStorageContainerNodeData visible={this.state.azStorageContainerVisible} />
                         <AZAppNodeData visible={this.state.azAppVisible} />
                         <AZManagementGroupNodeData visible={this.state.azManagementGroupVisible} />
                         <AZRoleNodeData visible={this.state.azRoleVisible} />

--- a/src/components/SearchContainer/TabContainer.jsx
+++ b/src/components/SearchContainer/TabContainer.jsx
@@ -29,6 +29,7 @@ import AZManagementGroupNodeData from "./Tabs/AZManagementGroupNodeData";
 import AZRoleNodeData from "./Tabs/AZRoleNodeData";
 import AZStorageAccountNodeData from './Tabs/AZStorageAccountNodeData';
 import AZStorageContainerNodeData from './Tabs/AZStorageContainerNodeData';
+import AZAutomationAccountNodeData from './Tabs/AZAutomationAccountNodeData';
 
 class TabContainer extends Component {
 
@@ -55,6 +56,7 @@ class TabContainer extends Component {
             azServicePrincipalVisible: false,
             azStorageAccountVisible: false,
             azStorageContainerVisible: false,
+            azAutomationAccountVisible: false,
             azAppVisible: false,
             azManagementGroupVisible: false,
             azRoleVisible: false,
@@ -117,6 +119,8 @@ class TabContainer extends Component {
             this._azStorageAccountNodeClicked();
         } else if (type === 'AZStorageContainer') {
             this._azStorageContainerNodeClicked();
+        } else if (type === 'AZAutomationAccount') {
+            this._azAutomationAccountNodeClicked();
         }
 
     }
@@ -311,6 +315,14 @@ class TabContainer extends Component {
         });
     }
 
+    _azAutomationAccountNodeClicked() {
+        this.clearVisible()
+        this.setState({
+            azAutomationAccountVisible: true,
+            selected: 2
+        });
+    }
+
     _azAppNodeClicked() {
         this.clearVisible()
         this.setState({
@@ -358,6 +370,7 @@ class TabContainer extends Component {
                                 !this.state.azServicePrincipalVisible &&
                                 !this.state.azStorageAccountVisble &&
                                 !this.state.azStorageContainerVisble &&
+                                !this.state.azAutomationAccountVisible &&
                                 !this.state.azAppVisible &&
                                 !this.state.baseVisible &&
                                 !this.state.azManagementGroupVisible &&
@@ -397,6 +410,7 @@ class TabContainer extends Component {
                         />
                         <AZStorageAccountNodeData visible={this.state.azStorageAccountVisble} />
                         <AZStorageContainerNodeData visible={this.state.azStorageContainerVisible} />
+                        <AZAutomationAccountNodeData visible={this.state.azAutomationAccountVisible} />
                         <AZAppNodeData visible={this.state.azAppVisible} />
                         <AZManagementGroupNodeData visible={this.state.azManagementGroupVisible} />
                         <AZRoleNodeData visible={this.state.azRoleVisible} />

--- a/src/components/SearchContainer/Tabs/AZAutomationAccountNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZAutomationAccountNodeData.jsx
@@ -11,7 +11,7 @@ import { Table } from 'react-bootstrap';
 import styles from './NodeData.module.css';
 import { AppContext } from '../../../AppContext';
 
-const AZStorageContainerNodeData = () => {
+const AZAutomationAccountNodeData = () => {
     const [visible, setVisible] = useState(false);
     const [objectid, setObjectid] = useState(null);
     const [label, setLabel] = useState(null);
@@ -28,13 +28,13 @@ const AZStorageContainerNodeData = () => {
     }, []);
 
     const nodeClickEvent = (type, id, blocksinheritance, domain) => {
-        if (type === 'AZStorageContainer') {
+        if (type === 'AZAutomationAccount') {
             setVisible(true);
             setObjectid(id);
             setDomain(domain);
             let session = driver.session();
             session
-                .run(`MATCH (n:AZStorageContainer {objectid: $objectid}) RETURN n AS node`, {
+                .run(`MATCH (n:AZAutomationAccount {objectid: $objectid}) RETURN n AS node`, {
                     objectid: id,
                 })
                 .then((r) => {
@@ -72,18 +72,25 @@ const AZStorageContainerNodeData = () => {
                             <tbody className='searchable'>
                                 <NodeCypherNoNumberLink
                                     target={objectid}
-                                    property='See Storage Container within Tenant'
-                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    property='See Automation Account within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
                                 />
                                 <NodeCypherNoNumberLink
                                     target={objectid}
-                                    property='Resource group / Storage Account'
-                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    property='See Automation Account within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
                                 />
-                                <NodeCypherNoNumberLink
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZAutomationAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZAutomationAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
                                     target={objectid}
-                                    property='Storage Account'
-                                    query='MATCH p = (d:AZStorageAccount)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    distinct
                                 />
                             </tbody>
                         </Table>
@@ -115,50 +122,40 @@ const AZStorageContainerNodeData = () => {
                             <tbody className='searchable'>
                                 <NodeCypherLinkComplex
                                     countQuery={
-                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
                                     }
                                     graphQuery={
-                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
                                     }
-                                    property={'Storage Container Owners'}
+                                    property={'Automation Account Owners'}
                                     target={objectid}
                                 />
                                 <NodeCypherLinkComplex
                                     countQuery={
-                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
                                     }
                                     graphQuery={
-                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
                                     }
-                                    property={'Storage Container Contributors'}
+                                    property={'Automation Account Contributors'}
                                     target={objectid}
                                 />
                                 <NodeCypherLinkComplex
                                     countQuery={
-                                        'MATCH p = (d)-[r:ReaderAndDataAccess*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
                                     }
                                     graphQuery={
-                                        'MATCH p = (d)-[r:ReaderAndDataAccess*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
-                                    }
-                                    property={'Storage Container Data Readers'}
-                                    target={objectid}
-                                />
-                                <NodeCypherLinkComplex
-                                    countQuery={
-                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
-                                    }
-                                    graphQuery={
-                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
                                     }
                                     property={'User Access Administrators'}
                                     target={objectid}
                                 />
                                 <NodeCypherLinkComplex
                                     countQuery={
-                                        'MATCH p = (d)-[r]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                        'MATCH p = (d)-[r]->(u:AZAutomationAccount {objectid: $objectid}) RETURN COUNT(p)'
                                     }
                                     graphQuery={
-                                        'MATCH p = (d)-[r]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                        'MATCH p = (d)-[r]->(u:AZAutomationAccount {objectid: $objectid}) RETURN p'
                                     }
                                     property={'All Relations'}
                                     target={objectid}
@@ -173,5 +170,5 @@ const AZStorageContainerNodeData = () => {
     );
 };
 
-AZStorageContainerNodeData.propTypes = {};
-export default AZStorageContainerNodeData;
+AZAutomationAccountNodeData.propTypes = {};
+export default AZAutomationAccountNodeData;

--- a/src/components/SearchContainer/Tabs/AZLogicAppNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZLogicAppNodeData.jsx
@@ -1,0 +1,174 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZLogicAppNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZLogicApp') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZLogicApp {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Logic App within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Logic App within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZLogicApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZLogicApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Logic App Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Logic App Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'User Access Administrators'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r]->(u:AZLogicApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r]->(u:AZLogicApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'All Relations'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZLogicAppNodeData.propTypes = {};
+export default AZLogicAppNodeData;

--- a/src/components/SearchContainer/Tabs/AZStorageAccountNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZStorageAccountNodeData.jsx
@@ -1,0 +1,194 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZStorageAccountNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZStorageAccount') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZStorageAccount {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Storage Account within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Storage Account within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZStorageAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZStorageAccount {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (u:AZStorageAccount {objectid: $objectid})-[r:AZContains*1..]->(d) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (u:AZStorageAccount {objectid: $objectid})-[r:AZContains*1..]->(d) RETURN p'
+                                    }
+                                    property={'Storage Containers'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:ReaderAndDataAccess*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:ReaderAndDataAccess*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Data Readers'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:StorageAccountKeyOperator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:StorageAccountKeyOperator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Account Key Operator'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'All Relations'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZStorageAccountNodeData.propTypes = {};
+export default AZStorageAccountNodeData;

--- a/src/components/SearchContainer/Tabs/AZStorageAccountNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZStorageAccountNodeData.jsx
@@ -172,6 +172,16 @@ const AZStorageAccountNodeData = () => {
                                 />
                                 <NodeCypherLinkComplex
                                     countQuery={
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZStorageAccount {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'User Access Administrators'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
                                         'MATCH p = (d)-[r]->(u:AZStorageAccount {objectid: $objectid}) RETURN COUNT(p)'
                                     }
                                     graphQuery={

--- a/src/components/SearchContainer/Tabs/AZStorageContainerNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZStorageContainerNodeData.jsx
@@ -1,0 +1,167 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZStorageContainerNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZStorageContainer') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZStorageContainer {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Storage Container within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='Resource group / Storage Account'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='Storage Account'
+                                    query='MATCH p = (d:AZStorageAccount)-[r:AZContains*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:ReaderAndDataAccess*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:ReaderAndDataAccess*1..]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Storage Container Data Readers'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r]->(u:AZStorageContainer {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r]->(u:AZStorageContainer {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'All Relations'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZStorageContainerNodeData.propTypes = {};
+export default AZStorageContainerNodeData;

--- a/src/components/SearchContainer/Tabs/AZWebAppNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZWebAppNodeData.jsx
@@ -1,0 +1,174 @@
+import React, { useContext, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import CollapsibleSection from './Components/CollapsibleSection';
+import NodeCypherLinkComplex from './Components/NodeCypherLinkComplex';
+import NodeCypherLink from './Components/NodeCypherLink';
+import NodeCypherNoNumberLink from './Components/NodeCypherNoNumberLink';
+import MappedNodeProps from './Components/MappedNodeProps';
+import ExtraNodeProps from './Components/ExtraNodeProps';
+import NodePlayCypherLink from './Components/NodePlayCypherLink';
+import { Table } from 'react-bootstrap';
+import styles from './NodeData.module.css';
+import { AppContext } from '../../../AppContext';
+
+const AZWebAppNodeData = () => {
+    const [visible, setVisible] = useState(false);
+    const [objectid, setObjectid] = useState(null);
+    const [label, setLabel] = useState(null);
+    const [domain, setDomain] = useState(null);
+    const [nodeProps, setNodeProps] = useState({});
+    const context = useContext(AppContext);
+
+    useEffect(() => {
+        emitter.on('nodeClicked', nodeClickEvent);
+
+        return () => {
+            emitter.removeListener('nodeClicked', nodeClickEvent);
+        };
+    }, []);
+
+    const nodeClickEvent = (type, id, blocksinheritance, domain) => {
+        if (type === 'AZWebApp') {
+            setVisible(true);
+            setObjectid(id);
+            setDomain(domain);
+            let session = driver.session();
+            session
+                .run(`MATCH (n:AZWebApp {objectid: $objectid}) RETURN n AS node`, {
+                    objectid: id,
+                })
+                .then((r) => {
+                    let props = r.records[0].get('node').properties;
+                    setNodeProps(props);
+                    setLabel(props.name || props.azname || objectid);
+                    session.close();
+                });
+        } else {
+            setObjectid(null);
+            setVisible(false);
+        }
+    };
+
+    const displayMap = {
+        objectid: 'Object ID',
+    };
+
+    return objectid === null ? (
+        <div></div>
+    ) : (
+        <div
+            className={clsx(
+                !visible && 'displaynone',
+                context.darkMode ? styles.dark : styles.light
+            )}
+        >
+            <div className={clsx(styles.dl)}>
+                <h5>{label || objectid}</h5>
+
+                <CollapsibleSection header='OVERVIEW'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Web App within Tenant'
+                                    query='MATCH p = (d:AZTenant)-[r:AZContains*1..]->(u:AZWebApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherNoNumberLink
+                                    target={objectid}
+                                    property='See Web App within Resource group'
+                                    query='MATCH p = (d:AZResourceGroup)-[r:AZContains*1..]->(u:AZWebApp {objectid: $objectid}) RETURN p'
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p=(:AZWebApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p=(:AZWebApp {objectid:$objectid})-[:AZManagedIdentity]->(n) RETURN p'
+                                    }
+                                    start={label}
+                                    property={'Managed Identities'}
+                                    target={objectid}
+                                    distinct
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+                <hr></hr>
+
+                <MappedNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+            
+                <hr></hr>
+
+                <ExtraNodeProps
+                    displayMap={displayMap}
+                    properties={nodeProps}
+                    label={label}
+                />
+                        
+                <hr></hr>
+
+                <CollapsibleSection header='Role Assignments'>
+                    <div className={styles.itemlist}>
+                        <Table>
+                            <thead></thead>
+                            <tbody className='searchable'>
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZWebApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Owner*1..]->(u:AZWebApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Web App Owners'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZWebApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:Contributor*1..]->(u:AZWebApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'Web App Contributors'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZWebApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r:UserAccessAdministrator*1..]->(u:AZWebApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'User Access Administrators'}
+                                    target={objectid}
+                                />
+                                <NodeCypherLinkComplex
+                                    countQuery={
+                                        'MATCH p = (d)-[r]->(u:AZWebApp {objectid: $objectid}) RETURN COUNT(p)'
+                                    }
+                                    graphQuery={
+                                        'MATCH p = (d)-[r]->(u:AZWebApp {objectid: $objectid}) RETURN p'
+                                    }
+                                    property={'All Relations'}
+                                    target={objectid}
+                                />
+                            </tbody>
+                        </Table>
+                    </div>
+                </CollapsibleSection>
+                
+            </div>
+        </div>
+    );
+};
+
+AZWebAppNodeData.propTypes = {};
+export default AZWebAppNodeData;

--- a/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
@@ -211,6 +211,11 @@ const DatabaseDataDisplay = () => {
                             index={index}
                             label={'AZStorageAccount'}
                         />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZAutomationAccount) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZAutomationAccount'}
+                        />
                     </tbody>
                 </Table>
             </CollapsibleSection>

--- a/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
@@ -206,6 +206,11 @@ const DatabaseDataDisplay = () => {
                             index={index}
                             label={'AZVM'}
                         />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZStorageAccount) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZStorageAccount'}
+                        />
                     </tbody>
                 </Table>
             </CollapsibleSection>

--- a/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
@@ -221,6 +221,11 @@ const DatabaseDataDisplay = () => {
                             index={index}
                             label={'AZLogicApp'}
                         />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZWebApp) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZWebApp'}
+                        />
                     </tbody>
                 </Table>
             </CollapsibleSection>

--- a/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
+++ b/src/components/SearchContainer/Tabs/DatabaseDataDisplay.jsx
@@ -216,6 +216,11 @@ const DatabaseDataDisplay = () => {
                             index={index}
                             label={'AZAutomationAccount'}
                         />
+                        <DatabaseDataLabel
+                            query={'MATCH (n:AZLogicApp) RETURN count(n) AS count'}
+                            index={index}
+                            label={'AZLogicApp'}
+                        />
                     </tbody>
                 </Table>
             </CollapsibleSection>


### PR DESCRIPTION
Added support for storage accounts, automation accounts, logic apps and webapps(both function apps and app services). These resources are now queried by Azurehound, along with their role assignments. Besides this the role assignments are also modelled as edges.

![image](https://user-images.githubusercontent.com/10261812/209783771-15157dd8-1cd6-4bf8-88c1-cc6cd164ff72.png)
![image](https://user-images.githubusercontent.com/10261812/209783613-e0612dce-6a43-498f-940e-94ab07dd773d.png)
![image](https://user-images.githubusercontent.com/10261812/209783714-e774ae31-0659-42fb-999f-2872bdf3c1a3.png)

Besides that the Node information tab is also populated with information and links to certain relations:
![image](https://user-images.githubusercontent.com/10261812/209783875-62ce3655-71ec-4f2f-bf28-56e23c503b45.png)
![image](https://user-images.githubusercontent.com/10261812/209783926-6e56fbd9-3bf0-4be0-9304-37304123eeb9.png)

Caveat: custom role assignments will be marked as undefined, need to find a way to model those as well.