### PR TITLE
small typo: whisper -> whisker

### DIFF
--- a/docs/data-analysis/edges.rst
+++ b/docs/data-analysis/edges.rst
@@ -1665,7 +1665,7 @@ To abuse this privilege, use Whisker:
 
     Whisker.exe add /target:<TargetPrincipal>
     
-For other optional parameters, view the Whisper documentation.
+For other optional parameters, view the Whisker documentation.
 
 Opsec Considerations
 --------------------

--- a/src/components/Modals/HelpTexts/AddKeyCredentialLink/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AddKeyCredentialLink/Abuse.jsx
@@ -18,7 +18,7 @@ const Abuse = ({ sourceName, sourceType }) => {
             </pre>
 
             <p>
-                For other optional parameters, view the Whisper documentation.
+                For other optional parameters, view the Whisker documentation.
             </p>
         </>
     );


### PR DESCRIPTION
update the small typo in the documentation. "whisper" -> "whisker". 

