### PR TITLE
Update sharphound.rst with up-to-date link

### DIFF
--- a/docs/data-collection/sharphound.rst
+++ b/docs/data-collection/sharphound.rst
@@ -9,7 +9,7 @@ Download the pre-compiled SharpHound binary and PS1 version at
 https://github.com/BloodHoundAD/BloodHound/tree/master/Collectors
 
 You can view the source code for SharpHound and build it from source
-by visiting the SharpHound repo at https://github.com/BloodHoundAD/SharpHound3
+by visiting the SharpHound repo at https://github.com/BloodHoundAD/SharpHound
 
 Basic Usage
 ^^^^^^^^^^^


### PR DESCRIPTION
SharpHound3 is now deprecated in favor of SharpHound