### PR TITLE
Fix AZResetPassword false positives

### DIFF
--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -670,7 +670,6 @@ const MenuContainer = () => {
                 pwResetRoles: [
                     '62E90394-69F5-4237-9190-012177145E10',
                     '7BE44C8A-ADAF-4E2A-84D6-AB2649E08A13',
-                    'FE930BE7-5E62-47DB-91AF-98C3A49A38B1',
                     '9980E02C-C2BE-4D73-94E8-173B1DC7CF3C',
                 ],
             },
@@ -801,12 +800,11 @@ const MenuContainer = () => {
         User Account Admin template id: fe930be7-5e62-47db-91af-98c3a49a38b1`,
             type: 'query',
             statement:
-                `MATCH (at:AZTenant)-[:AZContains]->(UserAccountAdmin)-[:AZHasRole]->(UserAccountAdminRole:AZRole {templateid:"FE930BE7-5E62-47DB-91AF-98C3A49A38B1"})
-                MATCH (NonTargets:AZUser)-[:AZHasRole]->(ar:AZRole)
-                WHERE NOT ar.templateid IN $UserAccountAdminTargetRoles
-                WITH COLLECT(NonTargets) AS NonTargets,at,UserAccountAdmin
-                MATCH (at)-[:AZContains]->(UserAccountAdminTargets:AZUser)-[:AZHasRole]->(arTargets)
-                WHERE NOT UserAccountAdminTargets IN NonTargets AND arTargets.templateid IN $UserAccountAdminTargetRoles
+                `MATCH (NonTargetsRoles:AZUser)-[:AZHasRole]->(ar:AZRole) WHERE NOT ar.templateid IN $UserAccountAdminTargetRoles
+                MATCH (NonTargetsGroups:AZUser)-[:AZMemberOf|AZOwns]->(:AZGroup {isassignabletorole: true})
+                MATCH (at:AZTenant)-[:AZContains]->(UserAccountAdmin)-[:AZHasRole]->(:AZRole {templateid:"FE930BE7-5E62-47DB-91AF-98C3A49A38B1"})
+                WITH COLLECT(NonTargetsRoles) + COLLECT(NonTargetsGroups) AS NonTargets, at, UserAccountAdmin
+                MATCH (at)-[:AZContains]->(UserAccountAdminTargets:AZUser) WHERE NOT UserAccountAdminTargets IN NonTargets
                 CALL {
                     WITH UserAccountAdmin, UserAccountAdminTargets
                     MERGE (UserAccountAdmin)-[:AZResetPassword]->(UserAccountAdminTargets)

--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -669,7 +669,6 @@ const MenuContainer = () => {
             params: {
                 pwResetRoles: [
                     '62E90394-69F5-4237-9190-012177145E10',
-                    '966707D0-3269-4727-9BE2-8C3A10F19B9D',
                     '7BE44C8A-ADAF-4E2A-84D6-AB2649E08A13',
                     'FE930BE7-5E62-47DB-91AF-98C3A49A38B1',
                     '9980E02C-C2BE-4D73-94E8-173B1DC7CF3C',
@@ -774,12 +773,11 @@ const MenuContainer = () => {
         Password Admin template id: 966707d0-3269-4727-9be2-8c3a10f19b9d`,
             type: 'query',
             statement:
-                `MATCH (at:AZTenant)-[:AZContains]->(PasswordAdmin)-[:AZHasRole]->(PasswordAdminRole:AZRole {templateid:"966707D0-3269-4727-9BE2-8C3A10F19B9D"})
-                MATCH (NonTargets:AZUser)-[:AZHasRole]->(ar:AZRole)
-                WHERE NOT ar.templateid IN $PasswordAdminTargetRoles
-                WITH COLLECT(NonTargets) AS NonTargets,at,PasswordAdmin
-                MATCH (at)-[:AZContains]->(PasswordAdminTargets:AZUser)-[:AZHasRole]->(arTargets)
-                WHERE NOT PasswordAdminTargets IN NonTargets AND arTargets.templateid IN $PasswordAdminTargetRoles
+                `MATCH (NonTargetsRoles:AZUser)-[:AZHasRole]->(ar:AZRole) WHERE NOT ar.templateid IN $PasswordAdminTargetRoles
+                MATCH (NonTargetsGroups:AZUser)-[:AZMemberOf|AZOwns]->(:AZGroup {isassignabletorole: true})
+                MATCH (at:AZTenant)-[:AZContains]->(PasswordAdmin)-[:AZHasRole]->(PasswordAdminRole:AZRole {templateid:"966707D0-3269-4727-9BE2-8C3A10F19B9D"})
+                WITH COLLECT(NonTargetsRoles) + COLLECT(NonTargetsGroups) AS NonTargets, at, PasswordAdmin
+                MATCH (at)-[:AZContains]->(PasswordAdminTargets:AZUser) WHERE NOT PasswordAdminTargets IN NonTargets
                 CALL {
                     WITH PasswordAdmin, PasswordAdminTargets
                     MERGE (PasswordAdmin)-[:AZResetPassword]->(PasswordAdminTargets)

--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -711,7 +711,7 @@ const MenuContainer = () => {
             statement:
                 `MATCH (NonTargetsRoles:AZUser)-[:AZHasRole]->(ar:AZRole) WHERE NOT ar.templateid IN $AuthAdminTargetRoles
                 MATCH (NonTargetsGroups:AZUser)-[:AZMemberOf|AZOwns]->(:AZGroup {isassignabletorole: true})
-                MATCH (at:AZTenant)-[:AZContains]->(AuthAdmin)-[:AZHasRole]->(AuthAdminRole:AZRole {templateid:"C4E39BD9-1100-46D3-8C65-FB160DA0071F"})
+                MATCH (at:AZTenant)-[:AZContains]->(AuthAdmin)-[:AZHasRole]->(:AZRole {templateid:"C4E39BD9-1100-46D3-8C65-FB160DA0071F"})
                 WITH COLLECT(NonTargetsRoles) + COLLECT(NonTargetsGroups) AS NonTargets, at, AuthAdmin
                 MATCH (at)-[:AZContains]->(AuthAdminTargets:AZUser) WHERE NOT AuthAdminTargets IN NonTargets
                 CALL {
@@ -774,7 +774,7 @@ const MenuContainer = () => {
             statement:
                 `MATCH (NonTargetsRoles:AZUser)-[:AZHasRole]->(ar:AZRole) WHERE NOT ar.templateid IN $PasswordAdminTargetRoles
                 MATCH (NonTargetsGroups:AZUser)-[:AZMemberOf|AZOwns]->(:AZGroup {isassignabletorole: true})
-                MATCH (at:AZTenant)-[:AZContains]->(PasswordAdmin)-[:AZHasRole]->(PasswordAdminRole:AZRole {templateid:"966707D0-3269-4727-9BE2-8C3A10F19B9D"})
+                MATCH (at:AZTenant)-[:AZContains]->(PasswordAdmin)-[:AZHasRole]->(:AZRole {templateid:"966707D0-3269-4727-9BE2-8C3A10F19B9D"})
                 WITH COLLECT(NonTargetsRoles) + COLLECT(NonTargetsGroups) AS NonTargets, at, PasswordAdmin
                 MATCH (at)-[:AZContains]->(PasswordAdminTargets:AZUser) WHERE NOT PasswordAdminTargets IN NonTargets
                 CALL {

--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -668,7 +668,6 @@ const MenuContainer = () => {
                         } IN TRANSACTIONS OF {} ROWS`.format(batchSize),
             params: {
                 pwResetRoles: [
-                    'C4E39BD9-1100-46D3-8C65-FB160DA0071F',
                     '62E90394-69F5-4237-9190-012177145E10',
                     '966707D0-3269-4727-9BE2-8C3A10F19B9D',
                     '7BE44C8A-ADAF-4E2A-84D6-AB2649E08A13',
@@ -712,12 +711,11 @@ const MenuContainer = () => {
         Authentication admin template id: c4e39bd9-1100-46d3-8c65-fb160da0071f`,
             type: 'query',
             statement:
-                `MATCH (at:AZTenant)-[:AZContains]->(AuthAdmin)-[:AZHasRole]->(AuthAdminRole:AZRole {templateid:"C4E39BD9-1100-46D3-8C65-FB160DA0071F"})
-                MATCH (NonTargets:AZUser)-[:AZHasRole]->(ar:AZRole)
-                WHERE NOT ar.templateid IN $AuthAdminTargetRoles
-                WITH COLLECT(NonTargets) AS NonTargets,at,AuthAdmin
-                MATCH (at)-[:AZContains]->(AuthAdminTargets:AZUser)-[:AZHasRole]->(arTargets)
-                WHERE NOT AuthAdminTargets IN NonTargets AND arTargets.templateid IN $AuthAdminTargetRoles
+                `MATCH (NonTargetsRoles:AZUser)-[:AZHasRole]->(ar:AZRole) WHERE NOT ar.templateid IN $AuthAdminTargetRoles
+                MATCH (NonTargetsGroups:AZUser)-[:AZMemberOf|AZOwns]->(:AZGroup {isassignabletorole: true})
+                MATCH (at:AZTenant)-[:AZContains]->(AuthAdmin)-[:AZHasRole]->(AuthAdminRole:AZRole {templateid:"C4E39BD9-1100-46D3-8C65-FB160DA0071F"})
+                WITH COLLECT(NonTargetsRoles) + COLLECT(NonTargetsGroups) AS NonTargets, at, AuthAdmin
+                MATCH (at)-[:AZContains]->(AuthAdminTargets:AZUser) WHERE NOT AuthAdminTargets IN NonTargets
                 CALL {
                     WITH AuthAdmin, AuthAdminTargets
                     MERGE (AuthAdmin)-[:AZResetPassword]->(AuthAdminTargets)

--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -670,7 +670,6 @@ const MenuContainer = () => {
                 pwResetRoles: [
                     'C4E39BD9-1100-46D3-8C65-FB160DA0071F',
                     '62E90394-69F5-4237-9190-012177145E10',
-                    '729827E3-9C14-49F7-BB1B-9608F156BBB8',
                     '966707D0-3269-4727-9BE2-8C3A10F19B9D',
                     '7BE44C8A-ADAF-4E2A-84D6-AB2649E08A13',
                     'FE930BE7-5E62-47DB-91AF-98C3A49A38B1',
@@ -746,12 +745,11 @@ const MenuContainer = () => {
         Helpdesk Admin template id: 729827e3-9c14-49f7-bb1b-9608f156bbb8`,
             type: 'query',
             statement:
-                `MATCH (at:AZTenant)-[:AZContains]->(HelpdeskAdmin)-[:AZHasRole]->(HelpdeskAdminRole:AZRole {templateid:"729827E3-9C14-49F7-BB1B-9608F156BBB8"})
-                MATCH (NonTargets:AZUser)-[:AZHasRole]->(ar:AZRole)
-                WHERE NOT ar.templateid IN $HelpdeskAdminTargetRoles
-                WITH COLLECT(NonTargets) AS NonTargets,at,HelpdeskAdmin
-                MATCH (at)-[:AZContains]->(HelpdeskAdminTargets:AZUser)-[:AZHasRole]->(arTargets)
-                WHERE NOT HelpdeskAdminTargets IN NonTargets AND arTargets.templateid IN $HelpdeskAdminTargetRoles
+                `MATCH (NonTargetsRoles:AZUser)-[:AZHasRole]->(ar:AZRole) WHERE NOT ar.templateid IN $HelpdeskAdminTargetRoles
+                MATCH (NonTargetsGroups:AZUser)-[:AZMemberOf|AZOwns]->(:AZGroup {isassignabletorole: true})
+                MATCH (at:AZTenant)-[:AZContains]->(HelpdeskAdmin)-[:AZHasRole]->(:AZRole {templateid:"729827E3-9C14-49F7-BB1B-9608F156BBB8"})
+                WITH COLLECT(NonTargetsRoles) + COLLECT(NonTargetsGroups) AS NonTargets, at, HelpdeskAdmin
+                MATCH (at)-[:AZContains]->(HelpdeskAdminTargets:AZUser) WHERE NOT HelpdeskAdminTargets IN NonTargets
                 CALL {
                     WITH HelpdeskAdmin, HelpdeskAdminTargets
                     MERGE (HelpdeskAdmin)-[:AZResetPassword]->(HelpdeskAdminTargets)


### PR DESCRIPTION
Some roles cannot reset the password of users that either own or are members of role-assignable groups. The queries to create `AZResetPassword` edges have been modified to take this into account for the following roles:

- Helpdesk Administrator
- Authentication Administrator
- Password Administrator
- User Administrator