### PR TITLE
Remove .bin extension from instruction

### DIFF
--- a/docs/installation/linux.rst
+++ b/docs/installation/linux.rst
@@ -96,7 +96,7 @@ Download the BloodHound GUI
 
 ::
 
-  ./BloodHound.bin --no-sandbox
+  ./BloodHound --no-sandbox
 
 3. Authenticate with the credentials you set up for neo4j
 


### PR DESCRIPTION
The current Linux binaries for version (4.2) is without the .bin file extension