### PR TITLE
Added import of "Group Types" and "Membership Rule" for AZGroups

### DIFF
--- a/src/components/SearchContainer/Tabs/AZGroupNodeData.jsx
+++ b/src/components/SearchContainer/Tabs/AZGroupNodeData.jsx
@@ -57,6 +57,8 @@ const AZGroupNodeData = () => {
         displayname: 'Display Name',
         whencreated: 'Creation Time',
         securityenabled: 'Security Enabled',
+        groupTypes: 'Group Types',
+        membershipRule: 'Membership Rule',
     };
 
     return objectid === null ? (

--- a/src/js/ingestion_types.js
+++ b/src/js/ingestion_types.js
@@ -227,7 +227,10 @@
  * @property {string} tenantId
  * @property {string} id
  * @property {string} tenantName
+ * @property {String} azureGroupTypes
+ * @property {String} azureMembershipRule
  */
+
 
 /**
  * @typedef {Object} AzureGroupMember

--- a/src/js/newingestion.js
+++ b/src/js/newingestion.js
@@ -1198,6 +1198,8 @@ export function convertAzureGroup(data, ingestionData) {
                 securityidentifier: data.securityIdentifier,
                 name: `${data.displayName}@${data.tenantName}`.toUpperCase(),
                 tenantid: data.tenantId.toUpperCase(),
+                groupTypes: data.groupTypes,
+                membershipRule: data.membershipRule,
             },
         },
         false


### PR DESCRIPTION
These are useful when looking for privilege escalation vectors (see https://www.mnemonic.io/resources/blog/abusing-dynamic-groups-in-azure-ad-for-privilege-escalation/).

Listing all dynamic groups can be done with `MATCH (g:AZGroup) WHERE any(gt IN g.groupTypes WHERE gt = "DynamicMembership") RETURN g`