### PR TITLE
Minor Update of Neo4J Compatible Version to 4.4.19

### DIFF
--- a/docs/installation/windows.rst
+++ b/docs/installation/windows.rst
@@ -14,7 +14,7 @@ Install neo4j
 
 .. Warning::
 
-  Neo4j 5 suffers from severe performance regression issues. Until further notice, please use Neo4j 4.4.13
+  Neo4j 5 suffers from severe performance regression issues. Until further notice, please use Neo4j 4.4.19 (https://neo4j.com/release-notes/database/neo4j-4-4-19/).
 
 1. Download the neo4j Community Server Edition zip from https://neo4j.com/download-center/#community
 


### PR DESCRIPTION
Reason: Improved accuracy - Neo4J 4.4.13 is not available to download anymore from the community page. Version 4.4.19 has been tested with a large tenant (50k principals) and works fine.