### PR TITLE
Add visualization of newly extracted data

### DIFF
--- a/src/components/Menu/MenuContainer.jsx
+++ b/src/components/Menu/MenuContainer.jsx
@@ -308,14 +308,31 @@ const MenuContainer = () => {
                         }
                     }
                 } else {
-                    for (let key in processedData) {
-                        let props = processedData[key].props;
-                        if (props.length === 0) continue;
-                        let chunked = props.chunk();
-                        let statement = processedData[key].statement;
+                    if (Array.isArray(processedData)) {
+                        for (let data in processedData) {
+                            data = processedData[data];
+                            for (let key in data) {
+                                let props = data[key].props;
+                                if (props.length === 0) continue;
+                                let chunked = props.chunk();
+                                let statement = data[key].statement;
 
-                        for (let chunk of chunked) {
-                            await uploadData(statement, chunk);
+                                for (let chunk of chunked) {
+                                    await uploadData(statement, chunk);
+                                }
+                            }
+                        }
+                    }
+                    else {
+                        for (let key in processedData) {
+                            let props = processedData[key].props;
+                            if (props.length === 0) continue;
+                            let chunked = props.chunk();
+                            let statement = processedData[key].statement;
+
+                            for (let chunk of chunked) {
+                                await uploadData(statement, chunk);
+                            }
                         }
                     }
                 }

--- a/src/js/ingestion_types.js
+++ b/src/js/ingestion_types.js
@@ -123,6 +123,7 @@
 /**
  * @typedef {Object} LinkType
  * @property {Dictionary.<string,int>} PasswordPolicies
+ * @property {Dictionary.<string,int>} LockoutPolicies
  * @property {Dictionary.<string,bool>} SMBSigning
  * @property {Dictionary.<string,bool>} LDAPSigning
  * @property {Dictionary.<string,int>} LMAuthenticationLevel

--- a/src/js/ingestion_types.js
+++ b/src/js/ingestion_types.js
@@ -115,6 +115,17 @@
  * @property {Array.<TypedPrincipal>} DcomUsers
  * @property {Array.<TypedPrincipal>} PSRemoteUsers
  * @property {Array.<TypedPrincipal>} AffectedComputers
+ * @property {boolean} BlockInheritance
+ * @property {LinkType} Unenforced
+ * @property {LinkType} Enforced
+ */
+
+/**
+ * @typedef {Object} LinkType
+ * @property {Dictionary.<string,int>} PasswordPolicies
+ * @property {Dictionary.<string,bool>} SMBSigning
+ * @property {Dictionary.<string,bool>} LDAPSigning
+ * @property {Dictionary.<string,int>} LMAuthenticationLevel
  */
 
 /**


### PR DESCRIPTION
Following the [BloodHoundAD/SharpHoundCommon#52](https://github.com/BloodHoundAD/SharpHoundCommon/pull/52) PR, which extracts more info related to GPO linked to the OU and the domains, this PR allows BloodHound to visualize the newly extracted data in the extra properties' section of a node. GPO precedences enforced, blockInheritance and nested OU are mainly managed here.