### PR TITLE
Corrects neo4j version

### DIFF
--- a/docs/installation/linux.rst
+++ b/docs/installation/linux.rst
@@ -30,7 +30,7 @@ Install neo4j
 ::
 
   wget -O - https://debian.neo4j.com/neotechnology.gpg.key | sudo apt-key add -
-  echo 'deb https://debian.neo4j.com stable 4' | sudo tee /etc/apt/sources.list.d/neo4j.list > /dev/null
+  echo 'deb https://debian.neo4j.com stable 4.4' | sudo tee /etc/apt/sources.list.d/neo4j.list > /dev/null
   sudo apt-get update
 
 2. Install apt-transport-https with apt


### PR DESCRIPTION
The Linux installation instructions currently omits the minor version for neo4j in the apt sources, causing errors. This PR fixes that.

According to [neo4j debian package page](https://debian.neo4j.com/):
`When adding the Neo4j repository to apt, you must specify the major version (and minor version if using 4.x Neo4j) you wish to use.`

See error below.
![image](https://github.com/BloodHoundAD/BloodHound/assets/17042203/f6f45502-54d0-497e-b4d0-dbb1180a0f18)
